### PR TITLE
Toggle floating ip reservation based on config

### DIFF
--- a/blazar_dashboard/conf.py
+++ b/blazar_dashboard/conf.py
@@ -1,0 +1,4 @@
+from django.conf import settings
+
+floatingip_reservation = (
+    getattr(settings, 'OPENSTACK_BLAZAR_FLOATINGIP_RESERVATION', {}))

--- a/blazar_dashboard/content/leases/templates/leases/_custom_lease_form.html
+++ b/blazar_dashboard/content/leases/templates/leases/_custom_lease_form.html
@@ -1,15 +1,15 @@
 {% load form_helpers %}
 <div class="alert alert-warning">
-        Please be courteous to other users of the testbed and make sure your lease represents a responsible 
-        use of Chameleon resources and complies with our 
+        Please be courteous to other users of the testbed and make sure your lease represents a responsible
+        use of Chameleon resources and complies with our
         <a href="https://chameleoncloud.readthedocs.io/en/latest/getting-started/faq.html#what-are-the-best-practices-for-chameleon-usage" target="blank">
-            best practices</a>. 
+            best practices</a>.
         Chameleon operators reserve the right to terminate leases judged to be abusive.
 </div>
 {% include 'horizon/common/_form_errors.html' with form=form %}
         <div class="row-fluid">
         {% include 'horizon/common/_form_field.html' with field=form.name %}
-        
+
     <p style="display:none;">
             Leave date and time values blank to start a lease immediately (on-demand).
     </p>
@@ -24,7 +24,7 @@
                 <label class="control-label {{ classes.label }} {% if form.number_of_days.field.required %}{{ form.required_css_class }}{% endif %}" for="{{ form.number_of_days.auto_id }}">
                     <span class="field-label">{{ form.number_of_days.label }}</span></label>
                 {% include "horizon/common/_form_field_decorator.html" with field=form.number_of_days  %}
-          
+
               <div class="{{ classes.value }} {{ form.number_of_days|wrapper_classes }}">
                   {{ form.number_of_days|add_bootstrap_class }}
               </div>
@@ -36,7 +36,7 @@
                 <label class="control-label {{ classes.label }} {% if form.end_date.field.required %}{{ form.required_css_class }}{% endif %}" for="{{ form.end_date.auto_id }}">
                     <span class="field-label">{{ form.end_date.label }}</span></label>
                 {% include "horizon/common/_form_field_decorator.html" with field=form.end_date  %}
-          
+
               <div class="{{ classes.value }} {{ form.end_date|wrapper_classes }}">
                   {{ form.end_date|add_bootstrap_class }}
               </div>
@@ -47,8 +47,6 @@
         </div>
         {% include 'horizon/common/_form_field.html' with field=form.end_time %}
 </div>
-
-{% comment "Not ready for floating ip reservations on this form yet" %} include 'horizon/common/_form_field.html' with field=form.network_ip_count {% endcomment %}
 
 <div class="left" style="margin-top:10px; border-right:1px solid lightgray;height:auto">
         <h4>Physical Hosts</h4>
@@ -68,5 +66,9 @@
         {% include 'horizon/common/_form_field.html' with field=form.resource_type_network %}
         {% include 'horizon/common/_form_field.html' with field=form.network_name %}
         {% include 'horizon/common/_form_field.html' with field=form.network_description %}
+
+        {% if enable_floatingip_reservations %}
+        {% include 'horizon/common/_form_field.html' with field=form.network_ip_count %}
+        {% endif %}
 </div>
 </div>

--- a/blazar_dashboard/content/leases/views.py
+++ b/blazar_dashboard/content/leases/views.py
@@ -26,6 +26,7 @@ from horizon.utils import memoized
 import pytz
 
 from blazar_dashboard import api
+from blazar_dashboard import conf
 from blazar_dashboard.content.leases import forms as project_forms
 from blazar_dashboard.content.leases import tables as project_tables
 from blazar_dashboard.content.leases import tabs as project_tabs
@@ -102,6 +103,8 @@ class CreateView(forms.ModalFormView):
         tz = pytz.timezone(self.request.session.get('django_timezone', self.request.COOKIES.get('django_timezone', 'UTC')))
         context['timezone'] = tz
         context['offset'] = int((pytz.datetime.datetime.now(tz).utcoffset().total_seconds() / 60) * -1)
+        context['enable_floatingip_reservations'] = (
+            conf.floatingip_reservation.get('network_id') is not None)
         return context
 
     # def get_success_url(self):


### PR DESCRIPTION
This adds support for an OPENSTACK_BLAZAR_FLOATINGIP_RESERVATION
setting, which can have a value of the form:

  {
    "network_id": <neutron_network_id>
  }

If network_id is set, then the UI for adding making a floating IP
reservation should appear in the lease create form.