### PR TITLE
Support multi-region floating ip reservation

### DIFF
--- a/blazar_dashboard/api/client.py
+++ b/blazar_dashboard/api/client.py
@@ -17,6 +17,7 @@ from datetime import datetime
 from itertools import chain
 import logging
 from pytz import UTC
+import re
 from six.moves.urllib.parse import urlparse
 
 from django.db import connections
@@ -26,6 +27,7 @@ import six
 from horizon import exceptions
 from horizon.utils.memoized import memoized
 from openstack_dashboard.api import base
+from openstack_dashboard.api import neutron
 
 from blazarclient import client as blazar_client
 
@@ -391,3 +393,13 @@ def extra_capability_values(request, name):
     rows += dictfetchall(cursor)
 
     return rows
+
+
+def get_floatingip_network_id(request, network_name_regex):
+    """Return default network id for floatingip reservation"""
+    pattern = re.compile(network_name_regex)
+    networks = [
+        n['id'] for n in neutron.network_list(request)
+        if re.match(pattern, str(n['name']))]
+
+    return networks[0]

--- a/blazar_dashboard/content/leases/forms.py
+++ b/blazar_dashboard/content/leases/forms.py
@@ -205,7 +205,8 @@ class CreateForm(forms.SelfHandlingForm):
                     'resource_properties': res_props,
                 })
         if data['network_ip_count'] > 0:
-            network_id = conf.floatingip_reservation.get('network_id')
+            network_id = api.client.get_floatingip_network_id(
+                request, conf.floatingip_reservation.get('network_name_regex'))
             reservations.append(
                 {
                     'resource_type': 'virtual:floatingip',

--- a/blazar_dashboard/content/leases/views.py
+++ b/blazar_dashboard/content/leases/views.py
@@ -75,7 +75,7 @@ def with_utc_dates(reservation):
 
     for date_key in ['start_date', 'end_date']:
         reservation[date_key] = add_utc_tz(reservation.get(date_key))
-        
+
     return reservation
 
 def extra_capability_names(request):
@@ -109,11 +109,13 @@ class CreateView(forms.ModalFormView):
 
     def get_context_data(self, **kwargs):
         context = super(CreateView, self).get_context_data(**kwargs)
-        tz = timezone(self.request.session.get('django_timezone', self.request.COOKIES.get('django_timezone', 'UTC')))
+        tz = timezone(self.request.session.get('django_timezone',
+                      self.request.COOKIES.get('django_timezone', 'UTC')))
         context['timezone'] = tz
-        context['offset'] = int((datetime.now(tz).utcoffset().total_seconds() / 60) * -1)
+        context['offset'] = int(
+            (datetime.now(tz).utcoffset().total_seconds() / 60) * -1)
         context['enable_floatingip_reservations'] = (
-            conf.floatingip_reservation.get('network_id') is not None)
+            conf.floatingip_reservation.get('network_name_regex') is not None)
         return context
 
     # def get_success_url(self):


### PR DESCRIPTION
With SSO users may have a mismatch between url and region. Since
floating ip reservations requires a network id for the external
network, horizon could only support making floating ip reservations
when site and url aligned because id provided in local settings.
This fix checks for the network name instead.

Note this fix only works if the external network for floating ips
has same name at both sites.

Change will also require adding blazar_floating_ip_reservation_network_name to site-configs and network_name in horizon's node_custom_configs.