### PR TITLE
Show node names on reservation calendar

### DIFF
--- a/blazar_dashboard/api/client.py
+++ b/blazar_dashboard/api/client.py
@@ -12,17 +12,15 @@
 
 from __future__ import absolute_import
 
-from collections import OrderedDict, defaultdict
+from collections import OrderedDict
 from datetime import datetime
 from itertools import chain
 import logging
 from pytz import UTC
 import re
-from six.moves.urllib.parse import urlparse
 
 from django.db import connections
 from django.utils.translation import ugettext_lazy as _
-import six
 
 from horizon import exceptions
 from horizon.utils.memoized import memoized
@@ -66,7 +64,8 @@ class Host(base.APIDictWrapper):
     _attrs = ['id', 'hypervisor_hostname', 'hypervisor_type',
               'hypervisor_version', 'vcpus', 'cpu_info', 'memory_mb',
               'local_gb', 'status', 'created_at', 'updated_at',
-              'service_name', 'trust_id', 'reservable', 'node_type']
+              'service_name', 'trust_id', 'reservable', 'node_type',
+              'node_name']
 
     def __init__(self, apiresource):
         super(Host, self).__init__(apiresource)
@@ -275,7 +274,8 @@ def reservation_calendar(request):
         return dict(
             hypervisor_hostname=h.hypervisor_hostname, vcpus=h.vcpus,
             memory_mb=h.memory_mb, local_gb=h.local_gb, cpu_info=h.cpu_info,
-            hypervisor_type=h.hypervisor_type, node_type=h.node_type)
+            hypervisor_type=h.hypervisor_type, node_type=h.node_type,
+            node_name=h.node_name)
 
     hosts_by_id = {h.id: h for h in host_list(request) if h.reservable}
 
@@ -287,7 +287,8 @@ def reservation_calendar(request):
             end_date=_parse_api_datestr(reservation['end_date']),
             id=reservation['id'],
             status=reservation.get('status'),
-            hypervisor_hostname=hosts_by_id[resource_id].hypervisor_hostname)
+            hypervisor_hostname=hosts_by_id[resource_id].hypervisor_hostname,
+            node_name=hosts_by_id[resource_id].node_name)
 
         return {k: v for k, v in host_reservation.items() if v is not None}
 

--- a/blazar_dashboard/content/leases/urls.py
+++ b/blazar_dashboard/content/leases/urls.py
@@ -20,12 +20,16 @@ from blazar_dashboard.content.leases import views as leases_views
 
 urlpatterns = [
     url(r'^calendar/$', leases_views.CalendarView.as_view(), name='calendar'),
-    url(r'^calendar\.json$', leases_views.calendar_data_view, name='calendar_data'),
+    url(r'^calendar\.json$', leases_views.calendar_data_view,
+        name='calendar_data'),
 
-    url(r'^network_calendar/$', leases_views.NetworkCalendarView.as_view(), name='network_calendar'),
-    url(r'^network_calendar\.json$', leases_views.network_calendar_data_view, name='network_calendar_data'),
+    url(r'^network_calendar/$', leases_views.NetworkCalendarView.as_view(),
+        name='network_calendar'),
+    url(r'^network_calendar\.json$', leases_views.network_calendar_data_view,
+        name='network_calendar_data'),
 
-    url(r'^extras/names$', leases_views.extra_capability_names, name='extra_names'),
+    url(r'^extras/names$', leases_views.extra_capability_names,
+        name='extra_names'),
     url(r'^extras/values/(?P<name>[^/]+)$',
         leases_views.extra_capability_values,
         name='extra_values'),

--- a/blazar_dashboard/static/leases/js/lease_gantt.js
+++ b/blazar_dashboard/static/leases/js/lease_gantt.js
@@ -53,12 +53,12 @@
             return r.id === this.id;
           },
           reservation
-        ).map(function(h) { return h.hypervisor_hostname; });
+        ).map(function(h) { return h.node_name; });
 
         return {
           'startDate': new Date(reservation.start_date),
           'endDate': new Date(reservation.end_date),
-          'taskName': reservation.hypervisor_hostname,
+          'taskName': reservation.node_name,
           'status': reservation.status,
           'data': reservation
         }
@@ -89,7 +89,7 @@
       chooser.prop('disabled', false);
 
       var taskNames = $.map(resp.compute_hosts, function(host, i) {
-        return host.hypervisor_hostname;
+        return host.node_name;
       });
       /* set initial time range */
       var timeDomain = computeTimeDomain(7);
@@ -161,7 +161,7 @@
 
       var filteredTaskNames = hosts
         .filter(function (host) {return nodeType === '*' || nodeType === host.node_type})
-        .map(function (host) {return host.hypervisor_hostname});
+        .map(function (host) {return host.node_name});
 
       tasks = all_tasks.filter(function(task) {
         return filteredTaskNames.indexOf(task.taskName) >= 0

--- a/blazar_dashboard/static/leases/js/vendor/d3.gantt.js
+++ b/blazar_dashboard/static/leases/js/vendor/d3.gantt.js
@@ -52,7 +52,7 @@ d3.gantt = function(options) {
     y = d3.scale.ordinal().domain(taskTypes).rangeRoundBands([0, height - margin.top - margin.bottom], .1);
     xAxis = makeXAxis().tickFormat(d3.time.format(tickFormat));
     yAxis = makeYAxis().tickFormat(function(d) {
-      return d.split('-')[0] + '...';
+      return d.split('-')[0];
     });
     gridX = makeXAxis().tickSize(-height + margin.top + margin.bottom, 0, 0).tickFormat('');
   };

--- a/lower-constraints.txt
+++ b/lower-constraints.txt
@@ -45,6 +45,7 @@ pyparsing==2.2.0
 pyperclip==1.6.0
 pyScss==1.3.4
 python-blazarclient==1.0.1
+python-ironicclient==1.11.0
 python-dateutil==2.7.0
 python-mimeparse==1.6.0
 pytz==2018.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@
 pbr!=2.1.0,>=2.0.0 # Apache-2.0
 -e git+https://github.com/ChameleonCloud/python-blazarclient.git@chameleoncloud/stable/train#egg=python_blazarclient-2.1.0
 horizon>=14.0.0.0b3  # Apache-2.0
+python-ironicclient>=1.11.0 # Apache-2.0


### PR DESCRIPTION
This replaces node uuids on reservation calendar with node names, which are more human readable. Implementation also requires adding node names to blazar host extra capabilities.