### PR TITLE
Add support for 'extras' field for calendar tooltip

### DIFF
--- a/blazar_dashboard/api/client.py
+++ b/blazar_dashboard/api/client.py
@@ -47,6 +47,9 @@ PRETTY_TYPE_NAMES = OrderedDict([
     ('arm64', _('ARM64')),
 ])
 
+PRETTY_EXTRA_LABELS = {
+    "name": _("Reserved by")
+}
 
 class Lease(base.APIDictWrapper):
     """Represents one Blazar lease."""
@@ -435,7 +438,8 @@ def device_reservation_calendar(request):
             id=reservation['id'],
             status=reservation.get('status'),
             device_name=devices_by_id[resource_id].name,
-            extras=reservation.get("extras"))
+            extras=[(PRETTY_EXTRA_LABELS[key], value) for key, value in reservation.get("extras").items()]
+        )
 
         return {k: v for k, v in device_reservation.items() if v is not None}
 

--- a/blazar_dashboard/api/client.py
+++ b/blazar_dashboard/api/client.py
@@ -434,7 +434,8 @@ def device_reservation_calendar(request):
             end_date=_parse_api_datestr(reservation['end_date']),
             id=reservation['id'],
             status=reservation.get('status'),
-            device_name=devices_by_id[resource_id].name)
+            device_name=devices_by_id[resource_id].name,
+            extras=reservation.get("extras"))
 
         return {k: v for k, v in device_reservation.items() if v is not None}
 

--- a/blazar_dashboard/static/leases/js/calendar/lease_chart.js
+++ b/blazar_dashboard/static/leases/js/calendar/lease_chart.js
@@ -211,12 +211,20 @@
         grid: { row: { colors: getGridBackground(resources) } },
         tooltip: {
           custom: function({series, seriesIndex, dataPointIndex, w}) {
-            var datum = rows[seriesIndex]
-            var resourcesReserved = datum.data.map(function(el){ return el.x }).join("<br>")
-            var project_dt = ""
+            var datum = rows[seriesIndex];
+            var resourcesReserved = datum.data.map(function(el){ return el.x }).join("<br>");
+            var project_dt = "";
             if(datum.project_id){
               project_dt = `<dt>${gettext("Project")}</dt>
-                <dd>${datum.project_id}</dd>`
+                <dd>${datum.project_id}</dd>`;
+            }
+            var extras_dt = "";
+            if(datum.extras){
+              datum.extras.forEach(function (item){
+                var title = item[0];
+                var value = item[1];
+                extras_dt += `<dt>${title}</dt><dd>${value}</dd>`;
+              });
             }
             return `<div class='tooltip-content'><dl>
               ${project_dt}
@@ -224,7 +232,8 @@
                 <dd>${resourcesReserved}</dd>
               <dt>${gettext("Reserved")}</dt>
                 <dd>${datum.start_date} <strong>${gettext("to")}</strong> ${datum.end_date}</dd>
-            </dl></div>`
+              ${extras_dt}
+            </dl></div>`;
           }
         },
         annotations: {


### PR DESCRIPTION
This is a list of extra things to appear on the tooltip, which are configured
in blazar. Note in this screenshot, we have "Reserved by" added from this
list of extras.

![image](https://user-images.githubusercontent.com/9397092/128571842-f88d1f48-e3eb-451a-9602-43d8f602e5e0.png)
