### PR TITLE
Add floating IP update screen, and fix update via JSON

### DIFF
--- a/blazar_dashboard/content/leases/workflows.py
+++ b/blazar_dashboard/content/leases/workflows.py
@@ -776,7 +776,7 @@ class UpdateLease(workflows.Workflow):
                     if res["resource_type"] == "virtual:floatingip"
                 ]
                 if len(existing_reservations) != 1:
-                    messages.error(request, "Cannot update node count for a lease "
+                    messages.error(request, "Cannot update floating IP amount for a lease "
                                             "with multiple floating IP reservations.")
                     return
                 existing_reservations[0]['amount'] = amount_floatingips
@@ -792,7 +792,7 @@ class UpdateLease(workflows.Workflow):
                 exceptions.handle(request, message="Invalid JSON provided")
                 return
 
-        if len(fields['reservations']) == 0:
+        if not fields['reservations']:
             del fields['reservations']
 
         if not is_update:


### PR DESCRIPTION
This change does a few things
- Previously, you could only use the host update screen if a host reservation was the only reservation in the lease
- There was no screen to update floating ip reservation, but now you can adjust the amount similar to adjusting min/max for a host reservation
- The JSON input box could not be used either, it just send the data as a string, which would cause a 500 error in blazar.