### PR TITLE
Explain in what case you need to reserve a network/floating ip on the workflow panel

### DIFF
--- a/blazar_dashboard/content/leases/templates/leases/create_lease/_network_help.html
+++ b/blazar_dashboard/content/leases/templates/leases/create_lease/_network_help.html
@@ -5,5 +5,20 @@
 <div class="alert alert-info">
 Network name is required when reserving a network.
 </div>
+<div id="network-warning" class="alert alert-warning" style="visibility: hidden">
+You are trying to lease an entire network segment VLAN!
+Are you sure you need to do this? It is possible to create a private
+layer 2 VLAN without needing a network reservation.
+<a href="https://chameleoncloud.readthedocs.io/en/latest/technical/networks/networks_vlan.html" target="_blank">
+  Learn more.
+</a>
+</div>
+<div id="ip-warning" class="alert alert-warning" style="visibility: hidden">
+Please be conservative with your reservations of floating IP addresses! There is typically
+no need to reserve more than one per-project for a given site.
+<a href="https://www.chameleoncloud.org/blog/2019/02/27/save-planet-use-fewer-ips/" target="_blank">
+  Learn more.
+</a>
+</div>
 {% endif %}
 {% endblock %}

--- a/blazar_dashboard/content/leases/templates/leases/create_lease/_network_help.html
+++ b/blazar_dashboard/content/leases/templates/leases/create_lease/_network_help.html
@@ -6,16 +6,16 @@
 Network name is required when reserving a network.
 </div>
 <div id="network-warning" class="alert alert-warning" style="visibility: hidden">
-You are trying to lease an entire network segment VLAN!
-Are you sure you need to do this? It is possible to create a private
-layer 2 VLAN without needing a network reservation.
+Network reservations are required for some advanced networking features, like stitching and the filesystem.
+It is possible to create a private layer 2 VLAN without a network reservation.
 <a href="https://chameleoncloud.readthedocs.io/en/latest/technical/networks/networks_vlan.html" target="_blank">
   Learn more.
 </a>
 </div>
 <div id="ip-warning" class="alert alert-warning" style="visibility: hidden">
-Please be conservative with your reservations of floating IP addresses! There is typically
-no need to reserve more than one per-project for a given site.
+Floating IP addresses are used to connect to an instance over the internet. There is typically
+no need to reserve more than one per-project for a given site. If there are no floating IPs available,
+try taking an ad-hoc IP (no reservation required).
 <a href="https://www.chameleoncloud.org/blog/2019/02/27/save-planet-use-fewer-ips/" target="_blank">
   Learn more.
 </a>

--- a/blazar_dashboard/content/leases/templates/leases/create_lease/_network_step.html
+++ b/blazar_dashboard/content/leases/templates/leases/create_lease/_network_step.html
@@ -10,17 +10,29 @@
 (function (window, horizon, $, undefined) {
     'use strict';
 
+    const toggleVisibility = function(div) {
+      if (div.style.visibility === "hidden") {
+        return "visible";
+      } else {
+        return "hidden";
+      }
+    }
+
     try {
     	document.addEventListener('network_capability_loaded', function() {
     		setResourceTypeInput('network');
     	}, false);
         $('#id_with_network').on('change', function() {
         	setResourceTypeInput('network');
+          const networkWarning = document.getElementById("network-warning");
+          networkWarning.style.visibility = toggleVisibility(networkWarning);
         });
         
         setResourceTypeInput('floatingip');
         $('#id_with_floatingip').on('change', function() {
         	setResourceTypeInput('floatingip');
+          const ipWarning = document.getElementById("ip-warning");
+          ipWarning.style.visibility = toggleVisibility(ipWarning);
         });
       } catch (err) {
         console.error(err);


### PR DESCRIPTION
The warnings will only activate when the relevant box is checked. This is done intentionally to make it more noticeable to the user (and hopefully cause them to read it).

![image](https://user-images.githubusercontent.com/14908880/178591132-4f36d23a-ef07-4af6-bd3e-f726e7387ab1.png)
![image](https://user-images.githubusercontent.com/14908880/178591270-272bdac5-2b38-4af3-8c7b-9f4145e1a562.png)