### PR TITLE
Create button for node reallocation

### DIFF
--- a/blazar_dashboard/api/client.py
+++ b/blazar_dashboard/api/client.py
@@ -220,6 +220,16 @@ def host_allocations_list(request):
     allocations = blazarclient(request).host.list_allocations()
     return [Allocation(a) for a in allocations]
 
+def host_reallocate(request, host_id, lease_id):
+    # Convert hypervisor hostname to numeric ID
+    host = next(
+        (host for host in host_list(request) if host.hypervisor_hostname == host_id),
+        None)
+    # If no host was found, send along the hypervisor hostname
+    # to get an error message from blazar
+    id_to_use = host.id if host else host_id
+    return blazarclient(request).host.reallocate(id_to_use, {"lease_id": lease_id})
+
 
 def host_capabilities_list(request):
     extra_capabilities = blazarclient(

--- a/blazar_dashboard/api/client.py
+++ b/blazar_dashboard/api/client.py
@@ -341,7 +341,9 @@ def nodes_in_lease(request, lease):
     hypervisor_by_host_id = {
         h.id: {
             'hypervisor_hostname': h.hypervisor_hostname,
-            'node_name': compute_host_display_name(h)}
+            'node_name': compute_host_display_name(h),
+            'reservable': h.reservable,
+        }
         for h in host_list(request)}
 
     return [
@@ -349,7 +351,9 @@ def nodes_in_lease(request, lease):
             hypervisor_hostname=hypervisor_by_host_id[h.resource_id].get(
                 'hypervisor_hostname'),
             node_name=hypervisor_by_host_id[h.resource_id].get('node_name'),
-            deleted=False)
+            deleted=False,
+            reservable=hypervisor_by_host_id[h.resource_id].get('reservable'),
+        )
         for h in host_allocations_list(request)
         if any((r['lease_id'] == lease['id']) for r in h.reservations)]
 

--- a/blazar_dashboard/content/leases/tabs.py
+++ b/blazar_dashboard/content/leases/tabs.py
@@ -66,3 +66,8 @@ class OverviewTab(tabs.Tab):
             site = sites.get(request.session.get('services_region'))
         return {'lease': lease, 'nodes': nodes, 'site': site,
                 'reservation_generals': RESERVATION_GENERALS, **csrf(request)}
+
+
+class LeaseDetailTabs(tabs.TabGroup):
+    slug = "lease_details"
+    tabs = (OverviewTab,)

--- a/blazar_dashboard/content/leases/tabs.py
+++ b/blazar_dashboard/content/leases/tabs.py
@@ -12,14 +12,19 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
+import logging
 
 from django.conf import settings
+from django.template.context_processors import csrf
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 from horizon import exceptions
+from horizon import messages
 from horizon import tabs
 
 from blazar_dashboard.api import client
+
+LOG = logging.getLogger(__name__)
 
 RESERVATION_GENERALS = (
     'id',
@@ -54,15 +59,47 @@ class OverviewTab(tabs.Tab):
             redirect = reverse('horizon:project:leases:index')
             msg = _('Unable to retrieve nodes in lease.')
             exceptions.handle(request, msg, redirect=redirect)
+            return
 
         site = None
         sites = getattr(settings, 'CHAMELEON_SITES')
         if sites:
             site = sites.get(request.session.get('services_region'))
+        for node in nodes:
+            if "reservable" not in node:
+                node["reservable"] = "_"
         return {'lease': lease, 'nodes': nodes, 'site': site,
-                'reservation_generals': RESERVATION_GENERALS}
+                'reservation_generals': RESERVATION_GENERALS, **csrf(request)}
+
+    def post(self, request, *args, **kwargs):
+        """
+        Handles requests made by buttons
+        """
+        host_reallocate = request.POST.get("host_reallocate")
+        if not host_reallocate:
+            LOG.error(f"Received malformed POST: {request.POST}")
+            return
+        try:
+            host_id, lease_id = host_reallocate.split(maxsplit=1)
+        except Exception:
+            exceptions.handle(request, _("Missing node ID or Lease ID"))
+            return
+
+        try:
+            client.host_reallocate(request, host_id, lease_id)
+        except Exception:
+            exceptions.handle(request, _("Could not reallocate host."))
+            return
+
+        messages.success(request, f"Reallocated host {host_id}. "
+                                  f"Updates may not appear in lease "
+                                  f"for a few more seconds.")
 
 
 class LeaseDetailTabs(tabs.TabGroup):
     slug = "lease_details"
     tabs = (OverviewTab,)
+
+    @property
+    def selected(self):
+        return self.get_tab(OverviewTab.slug)

--- a/blazar_dashboard/content/leases/tabs.py
+++ b/blazar_dashboard/content/leases/tabs.py
@@ -65,9 +65,6 @@ class OverviewTab(tabs.Tab):
         sites = getattr(settings, 'CHAMELEON_SITES')
         if sites:
             site = sites.get(request.session.get('services_region'))
-        for node in nodes:
-            if "reservable" not in node:
-                node["reservable"] = "_"
         return {'lease': lease, 'nodes': nodes, 'site': site,
                 'reservation_generals': RESERVATION_GENERALS, **csrf(request)}
 

--- a/blazar_dashboard/content/leases/tabs.py
+++ b/blazar_dashboard/content/leases/tabs.py
@@ -59,7 +59,6 @@ class OverviewTab(tabs.Tab):
             redirect = reverse('horizon:project:leases:index')
             msg = _('Unable to retrieve nodes in lease.')
             exceptions.handle(request, msg, redirect=redirect)
-            return
 
         site = None
         sites = getattr(settings, 'CHAMELEON_SITES')
@@ -67,36 +66,3 @@ class OverviewTab(tabs.Tab):
             site = sites.get(request.session.get('services_region'))
         return {'lease': lease, 'nodes': nodes, 'site': site,
                 'reservation_generals': RESERVATION_GENERALS, **csrf(request)}
-
-    def post(self, request, *args, **kwargs):
-        """
-        Handles requests made by buttons
-        """
-        host_reallocate = request.POST.get("host_reallocate")
-        if not host_reallocate:
-            LOG.error(f"Received malformed POST: {request.POST}")
-            return
-        try:
-            host_id, lease_id = host_reallocate.split(maxsplit=1)
-        except Exception:
-            exceptions.handle(request, _("Missing node ID or Lease ID"))
-            return
-
-        try:
-            client.host_reallocate(request, host_id, lease_id)
-        except Exception:
-            exceptions.handle(request, _("Could not reallocate host."))
-            return
-
-        messages.success(request, f"Reallocated host {host_id}. "
-                                  f"Updates may not appear in lease "
-                                  f"for a few more seconds.")
-
-
-class LeaseDetailTabs(tabs.TabGroup):
-    slug = "lease_details"
-    tabs = (OverviewTab,)
-
-    @property
-    def selected(self):
-        return self.get_tab(OverviewTab.slug)

--- a/blazar_dashboard/content/leases/templates/leases/_detail_overview.html
+++ b/blazar_dashboard/content/leases/templates/leases/_detail_overview.html
@@ -73,7 +73,7 @@
   <div class="info detail">
     <h4>{% trans "Nodes" %}</h4>
     <hr class="header_rule">
-    <form role="form" method="post">
+    <form role="form" method="post" action="{% url 'horizon:project:leases:reallocate' lease.id %}">
       {% csrf_token %}
       <dl class="dl-horizontal">
         {% for node in nodes %}

--- a/blazar_dashboard/content/leases/templates/leases/_detail_overview.html
+++ b/blazar_dashboard/content/leases/templates/leases/_detail_overview.html
@@ -89,9 +89,7 @@
               {% endif %}
               <b>
                 (status:
-                {% if node.reservable == "_" %}
-                  unknown)
-                {% elif node.reservable %}
+                {% if node.reservable %}
                   healthy)
                 {% else %}
                   unhealthy)
@@ -99,7 +97,7 @@
               </b>
                 <button class="btn btn-danger btn-xs"
                         type="submit" name="host_reallocate"
-                        help_text="If your host has become unhealthy, please report it to the help desk so we can fix it."
+                        help_text="If your node is experiencing issues, please report it to the help desk so it can be fixed."
                         title="Replace this host with another which has the same resource properties."
                         value="{{ node.hypervisor_hostname }} {{ lease.id }}">
                   Re-Allocate Host

--- a/blazar_dashboard/content/leases/templates/leases/_detail_overview.html
+++ b/blazar_dashboard/content/leases/templates/leases/_detail_overview.html
@@ -73,20 +73,42 @@
   <div class="info detail">
     <h4>{% trans "Nodes" %}</h4>
     <hr class="header_rule">
-    <dl class="dl-horizontal">
-      {% for node in nodes %}
-        <dt></dt>
-        <dd>
-        {% if site %}
-          <a href="https://www.chameleoncloud.org/hardware/node/sites/{{ site }}/clusters/chameleon/nodes/{{ node.hypervisor_hostname }}/">
-            {{ node.node_name }} (uid: {{ node.hypervisor_hostname }})
-          </a>
-        {% else %}
-            {{ node.node_name }} (uid: {{ node.hypervisor_hostname }})
-        {% endif %}
-        </dd>
-      {% endfor %}
-    </dl>
+    <form role="form" method="post">
+      {% csrf_token %}
+      <dl class="dl-horizontal">
+        {% for node in nodes %}
+          <dt></dt>
+            <dd class="lease-detail-host-container" data-display="{{ node.node_name }}">
+              <span class="lease-detail-host-name">
+              {% if site %}
+                <a href="https://www.chameleoncloud.org/hardware/node/sites/{{ site }}/clusters/chameleon/nodes/{{ node.hypervisor_hostname }}/">
+                  {{ node.node_name }} (uid: {{ node.hypervisor_hostname }})
+                </a>
+              {% else %}
+                  {{ node.node_name }} (uid: {{ node.hypervisor_hostname }})
+              {% endif %}
+              <b>
+                (status:
+                {% if node.reservable == "_" %}
+                  unknown)
+                {% elif node.reservable %}
+                  healthy)
+                {% else %}
+                  unhealthy)
+                {% endif %}
+              </b>
+                <button class="btn btn-danger btn-xs"
+                        type="submit" name="host_reallocate"
+                        help_text="If your host has become unhealthy, please report it to the help desk so we can fix it."
+                        title="Replace this host with another which has the same resource properties."
+                        value="{{ node.hypervisor_hostname }} {{ lease.id }}">
+                  Re-Allocate Host
+                </button>
+              </span>
+            </dd>
+        {% endfor %}
+      </dl>
+    </form>
   </div>
 {% endif %}
 </div>

--- a/blazar_dashboard/content/leases/urls.py
+++ b/blazar_dashboard/content/leases/urls.py
@@ -33,4 +33,5 @@ urlpatterns = [
         name='detail'),
     url(LEASE_URL % 'update', leases_views.UpdateView.as_view(),
         name='update'),
+    url(LEASE_URL % 'reallocate', leases_views.ReallocateView.as_view(), name='reallocate'),
 ]

--- a/blazar_dashboard/enabled/_91_project_reservations_leases_panel.py
+++ b/blazar_dashboard/enabled/_91_project_reservations_leases_panel.py
@@ -22,6 +22,7 @@ ADD_PANEL = 'blazar_dashboard.content.leases.panel.Leases'
 
 ADD_SCSS_FILES = [
     'leases/scss/calendar.scss',
+    'leases/scss/detail_overview.scss',
     'leases/scss/widgets.scss',
 ]
 

--- a/blazar_dashboard/static/leases/scss/detail_overview.scss
+++ b/blazar_dashboard/static/leases/scss/detail_overview.scss
@@ -1,0 +1,12 @@
+.lease-detail-host-container {
+  display: flex;
+  align-items: center;
+}
+.lease-detail-host-name {
+  flex: 1;
+  padding-bottom: 1%;
+} .lease-detail-host-name > span:first-child {
+  flex: 1;
+} .lease-detail-host-name > span {
+  display: block;
+}


### PR DESCRIPTION
Adds a button to the Lease Overview tab which allows the user to reallocate any of the hosts allocated to their lease. Also shows the "status" of each node: healthy/unhealthy, which maps to reservable/unreservable, or "unknown" if "reservable" is not set.

In order to embed the buttons in the Lease Overview tab, a patch to Horizon had to be made: https://github.com/ChameleonCloud/horizon/pull/18

The front-end changes were a little complicated. Some extra tag parameters needed to be added in order to get all of the dialogue functioning properly. Horizon would normally inject this information for you when buttons are defined as python classes, but in this case, that was not possible.

Screenshots:

![image](https://user-images.githubusercontent.com/14908880/179300893-69e51eaa-aa9e-4a71-9cd0-4d7858479f6c.png)

![image](https://user-images.githubusercontent.com/14908880/179300952-61e8a2b5-ab83-47e5-a720-0da2d9fa2316.png)

![image](https://user-images.githubusercontent.com/14908880/179301019-7d2bc70a-275e-4eef-8e7b-d0ac3ca136e1.png)
