### PR TITLE
Fix filter on load and add filter header

### DIFF
--- a/blazar_dashboard/content/leases/templates/leases/calendar.html
+++ b/blazar_dashboard/content/leases/templates/leases/calendar.html
@@ -35,6 +35,7 @@
     <select disabled class="form-control" id="resource-type-chooser" name="resource-type-chooser">
     </select>
   </div>
+  <h2 id="blazar-calendar-filter-header"></h2>
 </form>
 <div class="blazar-calendar" id="blazar-calendar-{{resource_type}}">
   <div class="text-center">


### PR DESCRIPTION
The default filter now works properly on first load, and there is now also a header which clearly displays what is being filtered.

I tried my best to figure out how to put the chooser flavor text into the header message, but could not do it. I found like 5 tutorials online with different suggestions, but none of them worked. The closest I got was `$('#resource-type-chooser').text()` which gave me an empty string. Everything else was undefined or caused errors.
