### PR TITLE
Fix datepicker check in lease creation workflow

### DIFF
--- a/blazar_dashboard/content/leases/templates/leases/create_lease/_general_step.html
+++ b/blazar_dashboard/content/leases/templates/leases/create_lease/_general_step.html
@@ -36,7 +36,8 @@
 
     function setEndDateTime() {
       var startDate = $('#id_start_date').datepicker('getDate');
-      if (startDate == 'Invalid Date') {
+      // if startDate is null, or unspecified, use today
+      if (startDate === 'Invalid Date' || startDate === null) {
         startDate = new Date();
       }
 


### PR DESCRIPTION
The callback for the "number of days" selector checked the `startDate` datepicker for "Invalid Date," which is only returned for an input which does not resolve to a valid date. If the datepicker has not been set at all, it returns `null`. The callback function now also checks for `null`, to indicate that a start date has not been specified. This way, it will use today's date instead of the beginning of the Unix epoch.
