### PR TITLE
Add `usage_type=general` to default network properties for lease creation workflow

### DIFF
--- a/blazar_dashboard/api/client.py
+++ b/blazar_dashboard/api/client.py
@@ -252,9 +252,9 @@ def network_allocations_list(request):
 def network_capabilities_list(request):
     extra_capabilities = blazarclient(
         request).network.list_capabilities(detail=True)
-    extra_capabilities.append({'property': 'physical_network',
+    extra_capabilities.append({'property': 'usage_type',
                                'private': False,
-                               'capability_values': ['physnet1', 'vlan']})
+                               'capability_values': ['general', 'filesystem', 'stitchable']})
     return [ExtraCapability(e) for e in extra_capabilities]
 
 

--- a/blazar_dashboard/api/client.py
+++ b/blazar_dashboard/api/client.py
@@ -252,9 +252,6 @@ def network_allocations_list(request):
 def network_capabilities_list(request):
     extra_capabilities = blazarclient(
         request).network.list_capabilities(detail=True)
-    extra_capabilities.append({'property': 'usage_type',
-                               'private': False,
-                               'capability_values': ['general', 'filesystem', 'stitchable']})
     return [ExtraCapability(e) for e in extra_capabilities]
 
 

--- a/blazar_dashboard/static/leases/js/create_lease/extra_capability_widget.js
+++ b/blazar_dashboard/static/leases/js/create_lease/extra_capability_widget.js
@@ -2,7 +2,7 @@ function capabilitiesjs(resource_type, switchable_classname) {
     'use strict';
     
     var defaults = {'computehost': {'node_type': 'compute_skylake'},
-    		        'network': {'physical_network': 'physnet1'},
+    		        'network': {'usage_type': 'general'},
     		        'device': {'vendor': 'Raspberry Pi'}
     		        };
 


### PR DESCRIPTION
This adds a selection for `usage_type` as a network property to the network lease page, and sets `usage_type=general` as the default selection for new network leases.
