### PR TITLE
Update to use hosts_in_lease API

### DIFF
--- a/blazar_dashboard/api/client.py
+++ b/blazar_dashboard/api/client.py
@@ -180,6 +180,12 @@ def lease_delete(request, lease_id):
     blazarclient(request).lease.delete(lease_id)
 
 
+def nodes_in_lease(request, lease_id):
+    """Hosts in a lease"""
+    hosts = blazarclient(request).lease.hosts_in_lease(lease_id)
+    return [Host(h) for h in hosts]
+
+
 def host_list(request):
     """List hosts."""
     hosts = blazarclient(request).host.list()
@@ -330,32 +336,6 @@ def device_available(request, start_date, end_date):
 
 def compute_host_display_name(host):
     return getattr(host, 'node_name', 'node{}'.format(host.id))
-
-
-def nodes_in_lease(request, lease):
-    """Return list of hypervisor_hostnames in a lease."""
-    if not any(
-            r['resource_type'] == 'physical:host' for r in lease['reservations']):
-        return []
-
-    hypervisor_by_host_id = {
-        h.id: {
-            'hypervisor_hostname': h.hypervisor_hostname,
-            'node_name': compute_host_display_name(h),
-            'reservable': h.reservable,
-        }
-        for h in host_list(request)}
-
-    return [
-        dict(
-            hypervisor_hostname=hypervisor_by_host_id[h.resource_id].get(
-                'hypervisor_hostname'),
-            node_name=hypervisor_by_host_id[h.resource_id].get('node_name'),
-            deleted=False,
-            reservable=hypervisor_by_host_id[h.resource_id].get('reservable'),
-        )
-        for h in host_allocations_list(request)
-        if any((r['lease_id'] == lease['id']) for r in h.reservations)]
 
 
 def reservation_calendar(request):

--- a/blazar_dashboard/content/leases/tabs.py
+++ b/blazar_dashboard/content/leases/tabs.py
@@ -54,7 +54,7 @@ class OverviewTab(tabs.Tab):
             exceptions.handle(request, msg, redirect=redirect)
 
         try:
-            nodes = client.nodes_in_lease(self.request, lease)
+            nodes = client.hosts_in_lease(self.request, lease.id)
         except Exception:
             redirect = reverse('horizon:project:leases:index')
             msg = _('Unable to retrieve nodes in lease.')


### PR DESCRIPTION
`nodes_in_lease` function to use new `hosts_in_lease` api instead of using allocations API to formulate the lease allocations