### PR TITLE
Backport upstream fix to our branch, details below:

### DIFF
--- a/blazar_dashboard/api/client.py
+++ b/blazar_dashboard/api/client.py
@@ -19,7 +19,7 @@ from pytz import UTC
 from blazarclient import client as blazar_client
 from collections import OrderedDict
 from django.db import connections
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from horizon import exceptions
 from horizon.utils.memoized import memoized
 import json

--- a/blazar_dashboard/content/hosts/forms.py
+++ b/blazar_dashboard/content/hosts/forms.py
@@ -13,7 +13,7 @@
 import json
 import logging
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from horizon import exceptions
 from horizon import forms
 from horizon import messages

--- a/blazar_dashboard/content/hosts/panel.py
+++ b/blazar_dashboard/content/hosts/panel.py
@@ -10,7 +10,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 import horizon
 
 

--- a/blazar_dashboard/content/hosts/tables.py
+++ b/blazar_dashboard/content/hosts/tables.py
@@ -11,8 +11,8 @@
 #    under the License.
 
 from django.template import defaultfilters as filters
-from django.utils.translation import ugettext_lazy as _
-from django.utils.translation import ungettext_lazy
+from django.utils.translation import gettext_lazy as _
+from django.utils.translation import ngettext_lazy
 from horizon import tables
 from horizon.templatetags import sizeformat
 
@@ -42,7 +42,7 @@ class DeleteHost(tables.DeleteAction):
 
     @staticmethod
     def action_present(count):
-        return ungettext_lazy(
+        return ngettext_lazy(
             u"Delete Host",
             u"Delete Hosts",
             count
@@ -50,7 +50,7 @@ class DeleteHost(tables.DeleteAction):
 
     @staticmethod
     def action_past(count):
-        return ungettext_lazy(
+        return ngettext_lazy(
             u"Deleted Host",
             u"Deleted Hosts",
             count

--- a/blazar_dashboard/content/hosts/tabs.py
+++ b/blazar_dashboard/content/hosts/tabs.py
@@ -14,7 +14,7 @@
 #    under the License.
 
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from horizon import exceptions
 from horizon import tabs
 

--- a/blazar_dashboard/content/hosts/views.py
+++ b/blazar_dashboard/content/hosts/views.py
@@ -11,7 +11,7 @@
 #    under the License.
 
 from django.urls import reverse_lazy
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from horizon import exceptions
 from horizon import forms
 from horizon import tables

--- a/blazar_dashboard/content/hosts/workflows.py
+++ b/blazar_dashboard/content/hosts/workflows.py
@@ -13,7 +13,7 @@
 import json
 import logging
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from horizon import exceptions
 from horizon import forms
 from horizon import messages

--- a/blazar_dashboard/content/leases/panel.py
+++ b/blazar_dashboard/content/leases/panel.py
@@ -13,7 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 import horizon
 
 

--- a/blazar_dashboard/content/leases/tables.py
+++ b/blazar_dashboard/content/leases/tables.py
@@ -20,8 +20,8 @@ import pytz
 from blazar_dashboard import api
 from blazar_dashboard import conf
 from django.template import defaultfilters as django_filters
-from django.utils.translation import ugettext_lazy as _
-from django.utils.translation import ungettext_lazy
+from django.utils.translation import gettext_lazy as _
+from django.utils.translation import ngettext_lazy
 from functools import partial
 from horizon import tables
 from horizon.utils import filters
@@ -88,7 +88,7 @@ class DeleteLease(tables.DeleteAction):
 
     @staticmethod
     def action_present(count):
-        return ungettext_lazy(
+        return ngettext_lazy(
             u"Delete Lease",
             u"Delete Leases",
             count
@@ -96,7 +96,7 @@ class DeleteLease(tables.DeleteAction):
 
     @staticmethod
     def action_past(count):
-        return ungettext_lazy(
+        return ngettext_lazy(
             u"Deleted Lease",
             u"Deleted Leases",
             count

--- a/blazar_dashboard/content/leases/tabs.py
+++ b/blazar_dashboard/content/leases/tabs.py
@@ -17,7 +17,7 @@ import logging
 from django.conf import settings
 from django.template.context_processors import csrf
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from horizon import exceptions
 from horizon import messages
 from horizon import tabs

--- a/blazar_dashboard/content/leases/utils.py
+++ b/blazar_dashboard/content/leases/utils.py
@@ -1,5 +1,5 @@
 from blazar_dashboard.api import client
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 import logging
 
 logger = logging.getLogger(__name__)

--- a/blazar_dashboard/content/leases/views.py
+++ b/blazar_dashboard/content/leases/views.py
@@ -24,7 +24,7 @@ from django.http import JsonResponse
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.urls import reverse_lazy
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import RedirectView
 from horizon import exceptions
 from horizon import messages

--- a/blazar_dashboard/content/leases/workflows.py
+++ b/blazar_dashboard/content/leases/workflows.py
@@ -6,7 +6,7 @@ from blazar_dashboard import api
 from blazar_dashboard import conf
 from django import template
 from django.urls import reverse_lazy
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from horizon import exceptions
 from horizon import forms
 from horizon import messages

--- a/blazar_dashboard/enabled/_90_admin_reservation_panelgroup.py
+++ b/blazar_dashboard/enabled/_90_admin_reservation_panelgroup.py
@@ -10,7 +10,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 # The slug of the panel group to be added to HORIZON_CONFIG. Required.
 PANEL_GROUP = 'reservation'

--- a/blazar_dashboard/enabled/_90_project_reservations_panelgroup.py
+++ b/blazar_dashboard/enabled/_90_project_reservations_panelgroup.py
@@ -10,7 +10,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 # The slug of the panel group to be added to HORIZON_CONFIG. Required.
 PANEL_GROUP = 'reservations'


### PR DESCRIPTION
Fix removed Django function calls

``ugettext_lazy`` and ``ungettext_lazy`` have been removed in Django v4.0 [1].

1. https://docs.djangoproject.com/en/dev/internals/deprecation/#deprecation-removed-in-4-0

Change-Id: Iaa809aa3698bb0a32293c1de430b57f33d7e6104