### PR TITLE
Fix network calendar rows showing up twice

### DIFF
--- a/blazar_dashboard/static/leases/js/calendar/lease_chart.js
+++ b/blazar_dashboard/static/leases/js/calendar/lease_chart.js
@@ -43,12 +43,12 @@
       nodeTypesPretty.forEach(function (nt) {
         if (availableResourceTypes[nt[0]]) {
           chooser.append(
-              new Option(
-                  nt[1],
-                  nt[0],
-                  nt[0] === "compute_skylake",
-                  nt[0] === "compute_skylake" // Set selected
-              )
+            new Option(
+              nt[1],
+              nt[0],
+              nt[0] === "compute_skylake",
+              nt[0] === "compute_skylake" // Set selected
+            )
           );
           delete availableResourceTypes[nt[0]];
         }
@@ -59,12 +59,12 @@
     selector = '#blazar-calendar-network'
     pluralResourceType = gettext("Networks")
     rowAttr = "segment_id";
-    
+
     chooserAttr = "network_type";
     chooserAttrPretty = gettext("Network Type");
     populateChooser = function (chooser, availableResourceTypes) {
       const networkTypesPretty = [
-          ['vlan', gettext("VLAN")],
+        ['vlan', gettext("VLAN")],
       ];
       networkTypesPretty.forEach((nt) => {
         if (availableResourceTypes[nt[0]]) {
@@ -134,18 +134,18 @@
       .done(function (resp) {
         projectId = resp.project_id;
 
-	// Fix network segment_id to string
-	if (selector === '#blazar-calendar-network') {
-	  resp.resources.forEach(function (resource) {
-	      resource[rowAttr] = resource[rowAttr].toString();
-	  });
-    resp.reservations.forEach(function (reservation) {
-      reservation[rowAttr] = reservation[rowAttr].toString();
-    });
-	}
-  fixedResources = resp.resources;
-	currentResources = fixedResources;
-	resources = fixedResources;
+        // Fix network segment_id to string
+        if (selector === '#blazar-calendar-network') {
+          resp.resources.forEach(function (resource) {
+            resource[rowAttr] = resource[rowAttr].toString();
+          });
+          resp.reservations.forEach(function (reservation) {
+            reservation[rowAttr] = reservation[rowAttr].toString();
+          });
+        }
+        fixedResources = resp.resources;
+        currentResources = fixedResources;
+        resources = fixedResources;
 
         var reservationsWithResources = resp.reservations;
         reservationsWithResources.forEach(function (reservation) {

--- a/blazar_dashboard/static/leases/js/calendar/lease_chart.js
+++ b/blazar_dashboard/static/leases/js/calendar/lease_chart.js
@@ -155,7 +155,6 @@
             }
           })
         });
-        console.log(reservationsWithResources)
         var reservationsById = {}
         reservationsWithResources.forEach(function (reservation) {
           if (!(reservation.id in reservationsById)) {
@@ -173,7 +172,6 @@
             ],
           }
           newReservation[chooserAttr] = reservation[chooserAttr]
-          console.log(newReservation)
           reservationsById[reservation.id].data.push(newReservation)
         })
         // Dummy data to force rendering of all resources

--- a/blazar_dashboard/static/leases/js/calendar/lease_chart.js
+++ b/blazar_dashboard/static/leases/js/calendar/lease_chart.js
@@ -137,13 +137,13 @@
 	// Fix network segment_id to string
 	if (selector === '#blazar-calendar-network') {
 	  resp.resources.forEach(function (resource) {
-	      let newResource = Object.assign({}, resource);
-	      newResource[rowAttr] = newResource[rowAttr].toString();
-	      fixedResources.push(newResource);
+	      resource[rowAttr] = resource[rowAttr].toString();
 	  });
-	} else {
-	  fixedResources = resp.resources;
+    resp.reservations.forEach(function (reservation) {
+      reservation[rowAttr] = reservation[rowAttr].toString();
+    });
 	}
+  fixedResources = resp.resources;
 	currentResources = fixedResources;
 	resources = fixedResources;
 
@@ -155,6 +155,7 @@
             }
           })
         });
+        console.log(reservationsWithResources)
         var reservationsById = {}
         reservationsWithResources.forEach(function (reservation) {
           if (!(reservation.id in reservationsById)) {
@@ -172,6 +173,7 @@
             ],
           }
           newReservation[chooserAttr] = reservation[chooserAttr]
+          console.log(newReservation)
           reservationsById[reservation.id].data.push(newReservation)
         })
         // Dummy data to force rendering of all resources
@@ -205,7 +207,6 @@
         } else {
           chooser.hide()
         }
-
         constructCalendar(filteredReservations, computeTimeDomain(7))
       })
       .fail(function () {


### PR DESCRIPTION
Bug: Networks appeared on the calendar twice when there was a reservation.

Both the resource and reservation treated segment_id as an integer,
which was only a problem because we were converting the
resource.segment_id to a string. This meant they weren't being matched
when generating the calendar rows, and so any resource with reservations
showed up twice, one for the string segment_id, one for the int
segment_id.

Note: Half of this is just a big formatting commit