### PR TITLE
Enable seeing usernames for leases from active project on the calendar

### DIFF
--- a/blazar_dashboard/api/client.py
+++ b/blazar_dashboard/api/client.py
@@ -385,7 +385,10 @@ def reservation_calendar(request):
             status=reservation.get('status'),
             hypervisor_hostname=hosts_by_id[resource_id].hypervisor_hostname,
             node_name=compute_host_display_name(hosts_by_id[resource_id]))
-
+        # Only include "extras" for reservations in the current project
+        if request.user.project_id == reservation.get('project_id'):
+            host_reservation["extras"] = [(PRETTY_EXTRA_LABELS.get(key, key), value)
+                    for key, value in reservation.get("extras").items()]
         return {k: v for k, v in host_reservation.items() if v is not None}
 
     host_reservations = [


### PR DESCRIPTION
This is already set up in the calendar for CHI@Edge, all we need to do for baremetal is to add on this "extras" data to the host reservation dictionary.