### PR TITLE
Remove blazarclient #egg requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@
 #
 # PBR should always appear first
 pbr!=2.1.0,>=2.0.0 # Apache-2.0
-git+https://github.com/ChameleonCloud/python-blazarclient.git@chameleoncloud/2023.1#egg=python_blazarclient
+git+https://github.com/ChameleonCloud/python-blazarclient.git@chameleoncloud/2023.1
 horizon>=17.1.0  # Apache-2.0


### PR DESCRIPTION
This is breaking CI, and is discouraged by the pip documentation:
- https://pip.pypa.io/en/stable/topics/vcs-support/#url-fragments