### PR TITLE
Add support for calendar traits

### DIFF
--- a/blazar_dashboard/api/client.py
+++ b/blazar_dashboard/api/client.py
@@ -333,6 +333,10 @@ def compute_host_display_name(host):
     return getattr(host, 'node_name', 'node{}'.format(host.id))
 
 
+def compute_host_display_type(host):
+    return getattr(host, 'node_type', 'unknown')
+
+
 def nodes_in_lease(request, lease):
     """Return list of hypervisor_hostnames in a lease."""
     if not any(
@@ -366,7 +370,7 @@ def reservation_calendar(request):
         host_dict = dict(
             hypervisor_hostname=h.hypervisor_hostname, vcpus=h.vcpus,
             memory_mb=h.memory_mb, local_gb=h.local_gb, cpu_info=h.cpu_info,
-            hypervisor_type=h.hypervisor_type, node_type=h.node_type,
+            hypervisor_type=h.hypervisor_type, node_type=compute_host_display_type(h),
             node_name=compute_host_display_name(h), reservable=h.reservable)
         # Copy these keys if they exist
         for key in ["authorized_projects", "restricted_reason"]:

--- a/blazar_dashboard/api/client.py
+++ b/blazar_dashboard/api/client.py
@@ -413,7 +413,14 @@ def flavor_reservation_calendar(request):
                 return []
 
         async def fetch_flavors():
-            return flavors(request)
+            # Filter flavors to exclude reserved flavors
+            return [
+                f for f in flavors(request)
+                if not any(
+                    k.startswith("resources:CUSTOM_RESERVATION_")
+                    for k in f["extra_specs"].keys()
+                )
+            ]
 
         async def fetch_traits(rp):
             try:

--- a/blazar_dashboard/api/client.py
+++ b/blazar_dashboard/api/client.py
@@ -10,6 +10,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import asyncio
 from datetime import datetime
 from itertools import chain
 import re
@@ -26,6 +27,7 @@ import logging
 from openstack_dashboard.api import base
 from openstack_dashboard.api import neutron
 from openstack_dashboard.api import _nova
+from openstack_dashboard.api import placement
 
 
 LOG = logging.getLogger(__name__)
@@ -401,9 +403,43 @@ def reservation_calendar(request):
 
 def flavor_reservation_calendar(request):
     hosts, reservations = reservation_calendar(request)
+
+    async def fetch_async_data():
+        async def fetch_resource_providers():
+            try:
+                return placement.resource_providers(request)
+            except Exception as e:
+                # If there is an issue with placment API, ignore it
+                return []
+
+        async def fetch_flavors():
+            return flavors(request)
+
+        async def fetch_traits(rp):
+            try:
+                rp["traits"] = placement.resource_provider_traits(
+                    request, rp["uuid"])
+            except Exception as e:
+                # If there is an issue with placment API, ignore it
+                return []
+
+        flavors_task = fetch_flavors()
+        rps = await fetch_resource_providers()
+        host_tasks = [fetch_traits(rp) for rp in rps]
+        *_, flavor_result = await asyncio.gather(*host_tasks, flavors_task)
+        return rps, flavor_result
+
+    # Fetch flavors and host traits. Hosts list is updated in place
+    resource_providers, f = asyncio.run(fetch_async_data())
+    rp_by_name = {
+        rp["name"]: rp for rp in resource_providers
+    }
+    for host in hosts:
+        host["traits"] = rp_by_name.get(
+            host["hypervisor_hostname"], {}).get("traits")
     return {
         "hosts": hosts,
-        "flavors": flavors(request),
+        "flavors": f,
     }, reservations
 
 def network_reservation_calendar(request):

--- a/blazar_dashboard/static/leases/js/calendar/lease_flavor_chart.js
+++ b/blazar_dashboard/static/leases/js/calendar/lease_flavor_chart.js
@@ -33,23 +33,6 @@
           // Max number of this flavor across all instances
           let flavor = resp.resources.flavors.find(f => f.id === flavorId);
 
-          function passesTraits(flavor, host){
-            let ret = true;
-            Object.keys(flavor["extra_specs"]).forEach(key => {
-              let value = flavor["extra_specs"][key];
-              if (key.startsWith("trait:")) {
-                let trait = key.split(":")[1];
-                let hostHasTrait = host["traits"].includes(trait);
-                if (value == "forbidden" && hostHasTrait) {
-                  ret = false
-                } else if (value == "required" && !hostHasTrait) {
-                  ret = false
-                }
-              }
-            })
-            return ret;
-          }
-
           return resp.resources.hosts.reduce(function (accumulator, host) {
             let totalVCPUs = host.vcpus;
             let totalMemory = host.memory_mb;
@@ -85,6 +68,23 @@
           }, []);
         }
 
+        function passesTraits(flavor, host){
+          let ret = true;
+          Object.keys(flavor["extra_specs"]).forEach(key => {
+            let value = flavor["extra_specs"][key];
+            if (key.startsWith("trait:")) {
+              let trait = key.split(":")[1];
+              let hostHasTrait = host["traits"].includes(trait);
+              if (value == "forbidden" && hostHasTrait) {
+                ret = false
+              } else if (value == "required" && !hostHasTrait) {
+                ret = false
+              }
+            }
+          })
+          return ret;
+        }
+
         function calculateAvailability(flavorId) {
           // Calculate the availability over time of this flavor
           // Outline: For each host
@@ -99,6 +99,11 @@
 
           let instanceChangeEvents = []
           resp.resources.hosts.forEach(host => {
+            if (!passesTraits(flavor, host)) {
+              // Ignore reservations on incompatible hosts
+              return
+            }
+
             // Calculate delta vcpus/memory at each reservation event
             let hostEvents = []
             resp.reservations.filter(r => r.hypervisor_hostname === host.hypervisor_hostname).forEach(reservation => {

--- a/blazar_dashboard/static/leases/js/calendar/lease_flavor_chart.js
+++ b/blazar_dashboard/static/leases/js/calendar/lease_flavor_chart.js
@@ -32,9 +32,34 @@
         function maxInstances(flavorId) {
           // Max number of this flavor across all instances
           let flavor = resp.resources.flavors.find(f => f.id === flavorId);
+
+          function passesTraits(flavor, host){
+            let ret = true;
+            Object.keys(flavor["extra_specs"]).forEach(key => {
+              let value = flavor["extra_specs"][key];
+              if (key.startsWith("trait:")) {
+                let trait = key.split(":")[1];
+                let hostHasTrait = host["traits"].includes(trait);
+                if (value == "forbidden" && hostHasTrait) {
+                  ret = false
+                } else if (value == "required" && !hostHasTrait) {
+                  ret = false
+                }
+              }
+            })
+            return ret;
+          }
+
           return resp.resources.hosts.reduce(function (accumulator, host) {
             let totalVCPUs = host.vcpus;
             let totalMemory = host.memory_mb;
+
+            if (!passesTraits(flavor, host)) {
+              // Host contributes 0 to capacity if traits don't match
+              totalVCPUs = 0
+              totalMemory = 0;
+            }
+
             return accumulator + Math.min(
               Math.floor(totalVCPUs / flavor.vcpus),
               Math.floor(totalMemory / flavor.ram)


### PR DESCRIPTION
Previously, we were not checking traits in the calendar.

Now when we compute host capacity, and show allocations, we take into account traits.

This also fixes the issue where node_type must be set on nodes or a 500 error occurs.

NOTE: this requires the following placement policy to permit users to list traits and providers. By default this is admin only.
```
"placement:resource_providers:traits:list": "@"
"placement:resource_providers:list": "@"
```