### PR TITLE
Add query parameter for selecting node type; use smart textbox

### DIFF
--- a/blazar_dashboard/content/leases/templates/leases/_widget_computehost_capabilities.html
+++ b/blazar_dashboard/content/leases/templates/leases/_widget_computehost_capabilities.html
@@ -1,27 +1,303 @@
 <div id="criteria-computehost" style="margin-bottom:50px" data-switchable-class="{{ widget.switchable_class }}">
-    <label id="no-criteria-warning-computehost" class="alert alert-danger" hidden="hidden">
-        <strong>No filters are specified,</strong> random hardware will be
-        assigned. Recommend that you
-        <a href="#" class="cri-adder" data-cri-name="node_type">add a filter for a node type</a>
-        or <a href="#" class="cri-adder" data-cri-name="uid">a specific node ID</a>.
-    </label>
-    <input id="criteria-payload-computehost" form_data="{{ widget.value }}" name="criteria-{{ widget.name }}" type="hidden">
-    <div>
-        <ul id="criteria-list-computehost" class="form-inline" style="padding-inline-start:0px;">
-        </ul>
+    <label>Resource Criteria (e.g., <code style="background-color: #f0f0f0; padding: 2px 4px; border-radius: 4px; color: #000000;">node_type == compute_skylake</code> or <code style="background-color: #f0f0f0; padding: 2px 4px; border-radius: 4px; color: #000000;">memory_mb >= 4096</code>)</label>
+    <div style="position: relative;">
+        <input id="criteria-payload-computehost"
+               type="text"
+               class="form-control"
+               placeholder="Enter filter like: node_type == compute_skylake, memory_mb >= 4096"
+               name="criteria-{{ widget.name }}"
+               value="{{ widget.value }}"
+               autocomplete="off"
+               style="margin-top: 10px; padding-right: 35px;">
+        <span id="validation-icon-computehost"
+              style="position: absolute; right: 15px; top: 50%; transform: translateY(-50%); font-size: 20px; display: none;"></span>
     </div>
-    <button id="criteria-add-computehost" style="margin-top:10px;float:right;" type="button" class="btn btn-sm btn-success {{ widget.switchable_class }}">Add Filter</button>
+
+    <!-- Warning message for empty criteria -->
+    <div id="empty-criteria-warning-computehost"
+         style="margin-top: 10px; padding: 12px 15px; background-color: #f8d7da; border: 1px solid #f5c6cb; border-radius: 4px; color: #721c24; display: none;">
+        <strong>⚠️ No filters are specified,</strong> random hardware will be assigned. Recommend that you
+        <a href="#" class="cri-adder" data-cri-name="node_type" style="color: #721c24; text-decoration: underline; font-weight: bold;">add a filter for a node type</a>
+        or
+        <a href="#" class="cri-adder" data-cri-name="uid" style="color: #721c24; text-decoration: underline; font-weight: bold;">a specific node name</a>.
+    </div>
+
+    <small class="form-text text-muted" style="margin-top: 5px;">
+        Format: <code style="background-color: #f0f0f0; padding: 2px 4px; border-radius: 4px; color: #000000;">property &lt;operator&gt; value</code> (e.g., <code style="background-color: #f0f0f0; padding: 2px 4px; border-radius: 4px; color: #000000;">node_name == node4</code>). Operators: <code style="background-color: #f0f0f0; padding: 2px 4px; border-radius: 4px; color: #000000;">==, !=, >=, <=, >, <</code>. Multiple filters separated by commas.
+    </small>
+    <small id="validation-message-computehost" class="form-text" style="margin-top: 5px; display: none; color: #dc3545;"></small>
+    <div id="autocomplete-suggestions-computehost" class="list-group" style="margin-top: 10px; display:none; position: absolute; z-index: 1000; width: 100%; background: white; border: 1px solid #ccc;"></div>
 </div>
 
 <script>
+// Initialize autocomplete for computehost criteria input with validation
+(function() {
+    var input = document.getElementById('criteria-payload-computehost');
+    var suggestionsDiv = document.getElementById('autocomplete-suggestions-computehost');
+    var validationIcon = document.getElementById('validation-icon-computehost');
+    var validationMessage = document.getElementById('validation-message-computehost');
+    var availableProperties = {};
 
-var cri_div = document.querySelector('#criteria-computehost');
-if (cri_div.dataset.loaded_once === undefined) {
-	capabilitiesjs('computehost', cri_div.dataset.switchableClass);
-	cri_div.dataset.loaded_once = true;
-	console.log('loaded criteria widget code')
-} else {
-	console.log('blocked reload of widget code :/');
-}
+    // If no value but we need a default, set it
+    if (!input.value || input.value.trim() === '') {
+        console.log('Setting default value');
+        input.value = 'node_type == compute_skylake';
+    }
 
+    // Load available properties
+    var propertiesLoaded = false;
+    var xhr = new XMLHttpRequest();
+    xhr.onreadystatechange = function() {
+        if (this.readyState == 4 && this.status == 200) {
+            availableProperties = JSON.parse(this.responseText)['extra_capabilities'];
+            propertiesLoaded = true;
+            // Validate after properties are loaded
+            if (input.value && input.value.length > 0) {
+                validateInput(input.value);
+            }
+        }
+    };
+    xhr.open('GET', '/project/leases/computehost/extras.json', true);
+    xhr.send();
+
+    function validateCriteria(criteria) {
+        criteria = criteria.trim();
+        if (!criteria) return null;
+
+        var operators = ['==', '!=', '<=', '>=', '<', '>'];
+        var operator = null;
+
+        for (var i = 0; i < operators.length; i++) {
+            if (criteria.includes(operators[i])) {
+                operator = operators[i];
+                break;
+            }
+        }
+
+        if (!operator) {
+            return 'Must use a valid operator: ' + operators.join(', ') + ' (e.g., node_name == node4)';
+        }
+
+        var parts = criteria.split(operator);
+        if (parts.length !== 2) {
+            return 'Invalid format - use a single operator per criterion.';
+        }
+
+        var propName = parts[0].trim();
+        var propValue = parts[1].trim();
+
+        if (!propName) {
+            return 'Property name is required before "' + operator + '"';
+        }
+        if (!propValue) {
+            return 'Property value is required after "' + operator + '"';
+        }
+
+        if (!propertiesLoaded) {
+            return null; // Cannot validate properties yet
+        }
+
+        if (!(propName in availableProperties)) {
+            return 'Property "' + propName + '" not found. Valid: ' + Object.keys(availableProperties).join(', ');
+        }
+
+        // For '==' and '!=' operators, validate against the list of known string values.
+        if (operator === '==' || operator === '!=') {
+            var validValues = availableProperties[propName];
+            if (validValues && validValues.length > 0 && validValues.indexOf(propValue) === -1) {
+                return 'Value "' + propValue + '" not valid for "' + propName + '". Valid: ' + validValues.join(', ');
+            }
+        }
+        // For other operators like '>', '<', etc., we assume a numeric or free-text value.
+        // Further validation (e.g., ensuring value is a number) could be added here if needed.
+
+        return null;
+    }
+
+    function validateInput(text) {
+        if (!text || text.trim() === '') {
+            validationIcon.style.display = 'none';
+            validationMessage.style.display = 'none';
+            return;
+        }
+
+        // If properties haven't loaded yet, show a pending state
+        if (!propertiesLoaded) {
+            validationIcon.innerHTML = '⏳';
+            validationIcon.style.color = '#ffc107';
+            validationIcon.style.display = 'inline-block';
+            validationMessage.style.display = 'none';
+            return;
+        }
+
+        var criteria = text.split(',');
+        for (var i = 0; i < criteria.length; i++) {
+            var error = validateCriteria(criteria[i]);
+            if (error) {
+                validationIcon.innerHTML = '❌';
+                validationIcon.style.color = '#dc3545';
+                validationIcon.style.display = 'inline-block';
+                validationMessage.innerHTML = error;
+                validationMessage.style.display = 'block';
+                return;
+            }
+        }
+
+        validationIcon.innerHTML = '✅';
+        validationIcon.style.color = '#28a745';
+        validationIcon.style.display = 'inline-block';
+        validationMessage.style.display = 'none';
+    }
+
+    // Handle input changes for autocomplete
+    input.addEventListener('input', function(e) {
+        var value = input.value;
+
+        // Show/hide warning based on whether input is empty
+        var warningDiv = document.getElementById('empty-criteria-warning-computehost');
+        if (!value || value.trim() === '') {
+            warningDiv.style.display = 'block';
+        } else {
+            warningDiv.style.display = 'none';
+        }
+
+        // Validate as user types
+        validateInput(value);
+
+        if (!value || value.length === 0) {
+            suggestionsDiv.style.display = 'none';
+            return;
+        }
+
+        // Get the last part after the comma (in case of multiple criteria)
+        var lastPart = value.substring(value.lastIndexOf(',') + 1).trim();
+        var beforeComma = value.substring(0, value.lastIndexOf(',') + 1);
+
+        var suggestions = [];
+        var operators = ['==', '!=', '<=', '>=', '<', '>'];
+        var foundOperator = null;
+        var operatorIndex = -1;
+
+        for (var i = 0; i < operators.length; i++) {
+            var idx = lastPart.indexOf(operators[i]);
+            if (idx > 0) {
+                foundOperator = operators[i];
+                operatorIndex = idx;
+                break;
+            }
+        }
+
+        if (foundOperator) {
+            var propName = lastPart.substring(0, operatorIndex).trim();
+            var partialValue = lastPart.substring(operatorIndex + foundOperator.length).trim();
+
+            if ((foundOperator === '==' || foundOperator === '!=') && (propName in availableProperties)) {
+                var values = availableProperties[propName];
+                if (values && values.length > 0) {
+                    for (var i = 0; i < values.length; i++) {
+                        if (values[i].toLowerCase().includes(partialValue.toLowerCase())) {
+                            suggestions.push({
+                                type: 'value',
+                                text: propName + ' ' + foundOperator + ' ' + values[i],
+                                full: beforeComma + propName + ' ' + foundOperator + ' ' + values[i]
+                            });
+                        }
+                    }
+                }
+            }
+        } else {
+            // Show matching property names
+            var currentKey = lastPart.trim();
+            if (currentKey.length > 0) {
+                for (var prop in availableProperties) {
+                    if (prop.includes(currentKey)) {
+                        suggestions.push({
+                            type: 'property',
+                            text: prop + ' == ', // Default to '==' for suggestions
+                            full: beforeComma + prop + ' == '
+                        });
+                    }
+                }
+            }
+        }
+
+        if (suggestions.length > 0) {
+            suggestionsDiv.innerHTML = suggestions.map(function(s) {
+                var label = s.type === 'property' ? '🔹 ' + s.text : '• ' + s.text;
+                return '<button type="button" class="list-group-item list-group-item-action" style="text-align: left; padding: 8px 12px; font-size: 14px;" data-value="' + s.full.replace(/"/g, '&quot;') + '">' + label + '</button>';
+            }).join('');
+            suggestionsDiv.style.display = 'block';
+
+            // Add click handlers
+            var buttons = suggestionsDiv.querySelectorAll('button');
+            buttons.forEach(function(btn) {
+                btn.addEventListener('click', function(e) {
+                    e.preventDefault();
+                    var newValue = btn.getAttribute('data-value');
+                    input.value = newValue;
+                    input.focus();
+                    input.dispatchEvent(new Event('input')); // Trigger validation
+                    suggestionsDiv.style.display = 'none';
+                });
+            });
+        } else {
+            suggestionsDiv.style.display = 'none';
+        }
+    });
+
+    // Hide suggestions when clicking elsewhere
+    document.addEventListener('click', function(e) {
+        if (e.target !== input && !suggestionsDiv.contains(e.target)) {
+            suggestionsDiv.style.display = 'none';
+        }
+    });
+
+    // Handle quick-add filter links in the warning
+    var quickAddLinks = document.querySelectorAll('.cri-adder');
+    quickAddLinks.forEach(function(link) {
+        link.addEventListener('click', function(e) {
+            e.preventDefault();
+            var filterName = link.getAttribute('data-cri-name');
+
+            // Get current value and append new filter
+            var currentValue = input.value.trim();
+            if (currentValue) {
+                // Append with comma separator
+                input.value = currentValue + ', ' + filterName + ' == ';
+            } else {
+                // Start with the filter name
+                input.value = filterName + ' == ';
+            }
+
+            // Focus and trigger input event to show suggestions
+            input.focus();
+            input.dispatchEvent(new Event('input'));
+        });
+    });
+
+    // Trigger validation on page load if there's an initial value
+    window.addEventListener('load', function() {
+        if (input.value && input.value.length > 0) {
+            input.dispatchEvent(new Event('input'));
+        } else {
+            // Show warning if field is empty on load
+            document.getElementById('empty-criteria-warning-computehost').style.display = 'block';
+        }
+    });
+
+    // Also validate immediately if value exists (for cases where load event already fired)
+    if (input.value && input.value.length > 0) {
+        setTimeout(function() {
+            input.dispatchEvent(new Event('input'));
+        }, 100);
+    } else {
+        // Show warning if empty on immediate load
+        setTimeout(function() {
+            var warning = document.getElementById('empty-criteria-warning-computehost');
+            if (!input.value || input.value.trim() === '') {
+                warning.style.display = 'block';
+            }
+        }, 100);
+    }
+})();
 </script>

--- a/blazar_dashboard/content/leases/templates/leases/calendar.html
+++ b/blazar_dashboard/content/leases/templates/leases/calendar.html
@@ -7,6 +7,25 @@
 {% endblock page_header %}
 
 {% block main %}
+<style>
+  .apexcharts-yaxis-label {
+    color: #0066cc !important;
+    fill: #0066cc !important;
+    text-decoration: underline !important;
+    cursor: pointer !important;
+  }
+  .apexcharts-yaxis-label:hover {
+    opacity: 0.8;
+  }
+  .apexcharts-yaxis text {
+    fill: #0066cc !important;
+  }
+</style>
+
+<div style="margin-bottom: 15px; padding: 10px; background-color: #e7f3ff; border-left: 4px solid #0066cc; border-radius: 3px;">
+  <strong>💡 Tip:</strong> Click on a node name to reserve it
+</div>
+
 <form class="form-inline" name="blazar-calendar-controls">
   <div class="form-group calendar-group">
     <button class="btn btn-sm btn-default calendar-quickdays" data-calendar-days="1">1 {% trans "day" %}</button>

--- a/blazar_dashboard/content/leases/views.py
+++ b/blazar_dashboard/content/leases/views.py
@@ -120,6 +120,16 @@ class DetailView(tabs.TabView):
 class CreateView(workflows.WorkflowView):
     workflow_class = project_workflows.CreateLease
 
+    def get_initial(self):
+        initial = super(CreateView, self).get_initial()
+        node_name = self.request.GET.get('node_name')
+        if node_name:
+            initial['with_computehost'] = True
+            initial['min_hosts'] = 1
+            initial['max_hosts'] = 1
+            initial['computehost_resource_properties'] = f'node_name == {node_name}'
+        return initial
+
 
 class UpdateView(workflows.WorkflowView):
     workflow_class = project_workflows.UpdateLease
@@ -174,5 +184,3 @@ class ReallocateView(RedirectView):
                                   f"for a few more seconds.")
 
         return redirect(next_url)
-
-

--- a/blazar_dashboard/content/leases/widgets.py
+++ b/blazar_dashboard/content/leases/widgets.py
@@ -1,10 +1,9 @@
 import datetime
+import json
 
-import collections
 from django.forms.widgets import Widget
 from django.template import loader
 from django.utils.safestring import mark_safe
-import json
 
 
 EQUALITIES = {
@@ -26,54 +25,77 @@ class CapabilityWidget(Widget):
         super(CapabilityWidget, self).__init__(*args, **kwargs)
 
     def get_context(self, name, value, attrs=None):
+        # Convert JSON back to plain text for display
+        display_value = value or ''
+        if display_value and display_value.startswith('['):
+            try:
+                data = json.loads(display_value)
+                criteria_list = []
+
+                if isinstance(data, list) and len(data) > 0:
+                    if data[0] == 'and':
+                        for item in data[1:]:
+                            if isinstance(item, list) and len(item) == 3:
+                                op, prop, val = item
+                                if isinstance(prop, str) and prop.startswith('$'):
+                                    prop = prop[1:]
+                                criteria_list.append('{} {} {}'.format(prop, op, val))
+                    else:
+                        if len(data) == 3:
+                            op, prop, val = data
+                            if isinstance(prop, str) and prop.startswith('$'):
+                                prop = prop[1:]
+                            criteria_list.append('{} {} {}'.format(prop, op, val))
+
+                display_value = ', '.join(criteria_list)
+            except (json.JSONDecodeError, ValueError, TypeError):
+                pass
+
         return {'widget': {
             'name': name,
-            'value': value,
+            'value': display_value,
             'switchable_class': self.switchable_class
         }}
 
     def render(self, name, value, attrs=None, renderer=None):
         context = self.get_context(name, value, attrs)
-        template = loader.get_template(self.template_name.format(
-            resource_type=self.resource_type)).render(context)
-        return mark_safe(template)
+        template_path = self.template_name.format(resource_type=self.resource_type)
+        return mark_safe(loader.get_template(template_path).render(context))
 
     def value_from_datadict(self, data, files, name):
-        prefix = 'criteria-{}-'.format(self.resource_type)
-        criteria_keys = (k for k in data if k.startswith(prefix))
+        text_value = data.get('criteria-' + name, '')
 
-        criteria = collections.defaultdict(dict)
-        for key in criteria_keys:
-            trimmed = key[len(prefix):]
-            arg, n = trimmed.split('-')
-            criteria[n][arg] = data[key]
-        criteria.default_factory = None
+        if not text_value or text_value.strip() == '':
+            return ''
 
+        operators = ['==', '!=', '<=', '>=', '<', '>']
         formatted_criteria = []
-        for criterion in criteria.values():
-            # (silently) filter incompletes
-            if not all(criterion.get(arg) for arg in ['name', 'equality', 'value']):
-                # del criteria[cr]
+
+        for item in text_value.split(','):
+            item = item.strip()
+            if not item:
                 continue
 
-            equality = EQUALITIES[criterion['equality']]
-            name = '$' + criterion['name']
-            value = criterion['value']
+            found_op = None
+            for op in operators:
+                if op in item:
+                    found_op = op
+                    break
 
-            formatted_criteria.append([equality, name, value])
-
-        formatted_criteria.sort(key=lambda x: x[2], reverse=True)
+            if found_op:
+                parts = item.split(found_op, 1)
+                if len(parts) == 2:
+                    prop_name = parts[0].strip()
+                    prop_value = parts[1].strip()
+                    if prop_name and prop_value:
+                        formatted_criteria.append([found_op, '$' + prop_name, prop_value])
 
         if len(formatted_criteria) < 1:
             resource_properties = ''
         elif len(formatted_criteria) == 1:
-            resource_properties = json.dumps(
-                formatted_criteria[0], separators=(',', ':'))
-        elif len(formatted_criteria) > 1:
-            resource_properties = ['and']
-            resource_properties.extend(formatted_criteria)
-            resource_properties = json.dumps(
-                resource_properties, separators=(',', ':'))
+            resource_properties = json.dumps(formatted_criteria[0], separators=(',', ':'))
+        else:
+            resource_properties = json.dumps(['and'] + formatted_criteria, separators=(',', ':'))
 
         return resource_properties
 

--- a/blazar_dashboard/content/leases/workflows.py
+++ b/blazar_dashboard/content/leases/workflows.py
@@ -4,7 +4,6 @@ import pytz
 
 from blazar_dashboard import api
 from blazar_dashboard import conf
-from django import template
 from django.urls import reverse_lazy
 from django.utils.translation import gettext_lazy as _
 from horizon import exceptions
@@ -222,6 +221,7 @@ class SetHostsAction(workflows.Action):
         required=False,
         help_text=_('Choose properties of the resource(s) to reserve.'),
         max_length=1024,
+        initial='node_type == compute_skylake',
         widget=widgets.CapabilityWidget(
             switchable_class='create-lease-switch-on-computehost',
             resource_type='computehost')
@@ -231,6 +231,30 @@ class SetHostsAction(workflows.Action):
         name = _("Hosts")
         help_text_template = ("project/leases/create_lease/"
                               "_host_help.html")
+
+    def __init__(self, request, context, *args, **kwargs):
+        self.request = request
+        self.context = context
+
+        # Check for node_name query parameter to override default resource properties
+        node_name = request.GET.get('node_name')
+        if node_name:
+            # Pre-fill with node_name filter in plain text format
+            if 'initial' not in kwargs:
+                kwargs['initial'] = {}
+            kwargs['initial']['computehost_resource_properties'] = 'node_name == ' + node_name
+            kwargs['initial']['with_computehost'] = True
+            kwargs['initial']['min_hosts'] = 1
+            kwargs['initial']['max_hosts'] = 1
+        else:
+            # No query param, but still set the other defaults
+            if 'initial' not in kwargs:
+                kwargs['initial'] = {}
+            kwargs['initial']['with_computehost'] = True
+            kwargs['initial']['min_hosts'] = 1
+            kwargs['initial']['max_hosts'] = 1
+
+        super().__init__(request, context, *args, **kwargs)
 
     def clean(self):
         cleaned_data = super(SetHostsAction, self).clean()
@@ -499,8 +523,10 @@ class CreateLease(workflows.Workflow):
         reservations = []
         if (data.get('with_computehost', False) and
             conf.host_reservation.get('enabled', False) and
-                data['min_hosts'] > 0 and data['max_hosts'] > 0):
+            data['min_hosts'] > 0 and data['max_hosts'] > 0
+        ):
             res_props = data.get('computehost_resource_properties', '')
+
             reservations.append(
                 {
                     'resource_type': 'physical:host',
@@ -509,11 +535,15 @@ class CreateLease(workflows.Workflow):
                     'hypervisor_properties': '',
                     'resource_properties': res_props,
                 })
+
         if (data.get('with_floatingip', False) and
             conf.floatingip_reservation.get('enabled', False) and
-                data['network_ip_count'] > 0):
+            data['network_ip_count'] > 0
+        ):
             network_id = api.client.get_floatingip_network_id(
-                request, conf.floatingip_reservation.get('network_name_regex'))
+                request,
+                conf.floatingip_reservation.get('network_name_regex')
+            )
             reservations.append(
                 {
                     'resource_type': 'virtual:floatingip',
@@ -521,9 +551,11 @@ class CreateLease(workflows.Workflow):
                     'amount': data['network_ip_count'],
                 }
             )
+
         if (data.get('with_network', False) and
             conf.network_reservation.get('enabled', False) and
-                data['network_name']):
+            data['network_name']
+        ):
             res_props = data.get('network_resource_properties', '')
             reservations.append(
                 {
@@ -533,9 +565,11 @@ class CreateLease(workflows.Workflow):
                     'network_properties': '',
                     'resource_properties': res_props,
                 })
+
         if (data.get('with_device', False) and
             conf.device_reservation.get('enabled', False) and
-                data['min_devices'] > 0 and data['max_devices'] > 0):
+            data['min_devices'] > 0 and data['max_devices'] > 0
+        ):
             res_props = data.get('device_resource_properties', '')
             reservations.append(
                 {

--- a/blazar_dashboard/static/leases/js/calendar/lease_chart.js
+++ b/blazar_dashboard/static/leases/js/calendar/lease_chart.js
@@ -19,6 +19,7 @@
     pluralResourceType = gettext("Hosts");
     chooserAttr = "node_type";
     chooserAttrPretty = gettext("Node Type");
+    var preselectedNodeType = new URLSearchParams(window.location.search).get('node_type') || "compute_skylake";
     populateChooser = function (chooser, availableResourceTypes) {
       var nodeTypesPretty = [ // preserve order so it's not random
         ['compute', gettext('Compute Node')],
@@ -42,12 +43,13 @@
       ];
       nodeTypesPretty.forEach(function (nt) {
         if (availableResourceTypes[nt[0]]) {
+          var isSelected = nt[0] === preselectedNodeType;
           chooser.append(
             new Option(
               nt[1],
               nt[0],
-              nt[0] === "compute_skylake",
-              nt[0] === "compute_skylake" // Set selected
+              isSelected,
+              isSelected
             )
           );
           delete availableResourceTypes[nt[0]];
@@ -200,6 +202,10 @@
           Object.keys(availableResourceTypes).forEach(function (key) {
             chooser.append(new Option(key, key));
           });
+          // Set the dropdown value to the preselected node type if it exists in the options
+          if (preselectedNodeType && chooser.find("option[value='" + preselectedNodeType + "']").length) {
+            chooser.val(preselectedNodeType);
+          }
           chooser.prop('disabled', false);
           chooser.change(onCalendarFilterChange);
         } else {
@@ -227,6 +233,16 @@
           },
           events: {
             updated: function (chartContext, config) {
+              $('.apexcharts-yaxis-label').css('cursor', 'pointer').off('click').on('click', function(e) {
+                  var nodeName = $(this).text();
+                  var createUrl = '../../create/?node_name=' + encodeURIComponent(nodeName);
+                  var link = document.createElement('a');
+                  link.setAttribute('href', createUrl);
+                  link.setAttribute('class', 'ajax-modal');
+                  document.body.appendChild(link);
+                  link.click();
+                  document.body.removeChild(link);
+              });
               $(`rect.apexcharts-grid-row[fill='${RESTRICTED_BACKGROUND_COLOR}']`).mouseout(function (event) {
                 $("#resource-disabled-tooltip").hide();
               });

--- a/blazar_dashboard/static/leases/js/create_lease/extra_capability_widget.js
+++ b/blazar_dashboard/static/leases/js/create_lease/extra_capability_widget.js
@@ -1,6 +1,6 @@
 function capabilitiesjs(resource_type, switchable_classname) {
     'use strict';
-    
+
     var defaults = {'computehost': {'node_type': 'compute_skylake'},
     		        'network': {'physical_network': 'physnet1'},
     		        'device': {'vendor': 'Raspberry Pi'}


### PR DESCRIPTION
I've added support for the following:
- query parameter for selecting the node type automatically when navigating to the host calendar (e.g. from portal)
- query parameter for selecting a node_name when being redirected to creating a lease (e.g. from portal)
- ability to click on a node name in the calendar to bring up the create lease box with the node pre-selected for reservation
- a smart textbox for specifying resource criteria instead of drop downs

Using the query parameter to navigate to the calendar:
<img width="1291" height="662" alt="Screenshot 2025-11-13 at 13 58 25" src="https://github.com/user-attachments/assets/d6938930-e218-4e9d-bf7b-be5378e7af19" />

Clicking on a node name on the calendar to bring up the create lease box (I had already typed in a lease name and clicked next, but this is what the host reservation page defaults to when you come to it via clicking in the calendar):
<img width="1282" height="632" alt="Screenshot 2025-11-13 at 13 58 51" src="https://github.com/user-attachments/assets/5763c437-0270-44ee-8a99-a7497cba12c3" />

Typing in the text box to specify different criteria (with suggestions below as you type):
<img width="720" height="621" alt="Screenshot 2025-11-13 at 13 59 14" src="https://github.com/user-attachments/assets/0fb47f28-177b-460c-906b-652cc0946152" />

If you clear the text box and don't specify any criteria, the warning it displays:
<img width="716" height="671" alt="Screenshot 2025-11-13 at 13 59 04" src="https://github.com/user-attachments/assets/eb1aee92-c60d-4da1-9b62-3a5706a38fc2" />

Providing multiple criteria:
<img width="714" height="578" alt="Screenshot 2025-11-14 at 11 12 38" src="https://github.com/user-attachments/assets/5302e727-3c22-49ca-b096-aaa828dd43bd" />
