### PR TITLE
Blazar dashboard fixes

### DIFF
--- a/blazar_dashboard/content/leases/views.py
+++ b/blazar_dashboard/content/leases/views.py
@@ -13,6 +13,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 import logging
+from concurrent.futures import ThreadPoolExecutor
 
 
 from blazar_dashboard import api
@@ -97,16 +98,40 @@ def calendar_data_view(request, resource_type):
 
 
 def extra_capabilities(request, resource_type):
+    extra_capabilities_function_map = {
+        "computehost": api.client.computehost_extra_capabilities,
+        "network": api.client.network_extra_capabilities,
+        "device": api.client.device_extra_capabilities
+    }
+    # Properties from the object to also fetch
+    object_properties_map = {
+        "device": ["name"],
+        "network": ["segment_id"],
+    }
+    object_list_function_map = {
+        "device": api.client.device_list,
+        "network": api.client.network_list,
+    }
+
     extra_capabilities = None
-    if resource_type == 'computehost':
-        extra_capabilities = api.client.computehost_extra_capabilities(
-            request)
-    elif resource_type == 'network':
-        extra_capabilities = api.client.network_extra_capabilities(
-            request)
-    elif resource_type == 'device':
-        extra_capabilities = api.client.device_extra_capabilities(
-            request)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        extra_capabilities_future = None
+        if resource_type in extra_capabilities_function_map:
+            extra_capabilities_future = executor.submit(extra_capabilities_function_map[resource_type], request)
+
+        objects = None
+        if resource_type in object_list_function_map:
+            objects_future = executor.submit(object_list_function_map[resource_type], request)
+            objects = objects_future.result()
+
+        if extra_capabilities_future:
+            extra_capabilities = extra_capabilities_future.result()
+            if objects:
+                for prop in object_properties_map[resource_type]:
+                    values = set()
+                    for obj in objects:
+                        values.add(obj.get(prop))
+                    extra_capabilities[prop] = list(values)
     data = {
         'extra_capabilities': extra_capabilities}
     return JsonResponse(data)

--- a/blazar_dashboard/content/leases/workflows.py
+++ b/blazar_dashboard/content/leases/workflows.py
@@ -360,15 +360,17 @@ class SetNetworksAction(workflows.Action):
     def clean(self):
         cleaned_data = super(SetNetworksAction, self).clean()
 
-        if not cleaned_data.get('with_network'):
-            return cleaned_data
-
-        if (not cleaned_data.get('network_name') and
-                cleaned_data.get('network_ip_count', 0) == 0):
+        if cleaned_data.get('with_network') and not cleaned_data.get('network_name'):
             raise forms.ValidationError(
                 "No network resource is reserved! "
                 "Clear \"Reserve Networks\" checkbox "
                 "if you don't need network resources.")
+
+        if cleaned_data.get('with_floatingip') and cleaned_data.get('network_ip_count', 0) == 0:
+            raise forms.ValidationError(
+                "No floating IP resource is reserved! "
+                "Clear \"Reserve Floating IPs\" checkbox "
+                "if you don't need floating IP resources.")
 
         return cleaned_data
 


### PR DESCRIPTION
1. Fixes create the create network dialog. If parameters were invalid/not given, no error was raised.
2. Adds in some specific attributes from the base resource to the reservation filter dropdown. Concurrently, this calls the resource list API endpoint, and collects the set of values for each attribute. At the moment, this is only configured for device "name" and network "segment_id".