### PR TITLE
fix(devstack): revert pyproject.toml to fix build

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,11 +1,6 @@
-[build-system]
-requires = ["pbr>=6.0.0", "setuptools>=64.0.0"]
-build-backend = "pbr.build"
-
-[tool.ruff]
 line-length = 79
 
-[tool.ruff.lint]
+[lint]
 select = [
     "E",        # pycodestyle (error)
     "F",        # pyflakes
@@ -22,7 +17,7 @@ ignore = [
     # "F401", # imported but unused
 ]
 
-[tool.ruff.lint.per-file-ignores]
+[lint.per-file-ignores]
 "blazar_dashboard/test/settings.py" = [
     # "F405", #HORIZON_CONFIG` may be undefined, or defined from star imports
 ]


### PR DESCRIPTION
Having a pyproject.toml file means that pip install --editable won't create .egg files. Since 2023.1 devstack doesn't support pep660, this breaks devstack installation of our fork.

devstack supports pyproject.toml starting 2024.1 https://github.com/openstack/devstack/commit/4ddd456dd3e71bcdf9a02a12dd5914b82ec48e91