### PR TITLE
feat: virtual leases panel for flavor reservations

### DIFF
--- a/blazar_dashboard/api/client.py
+++ b/blazar_dashboard/api/client.py
@@ -434,7 +434,14 @@ def flavor_reservation_calendar(request):
                 return []
 
         async def fetch_flavors():
-            return flavors(request)
+            # Filter flavors to exclude reserved flavors
+            return [
+                f for f in flavors(request)
+                if not any(
+                    k.startswith("resources:CUSTOM_RESERVATION_")
+                    for k in f["extra_specs"].keys()
+                )
+            ]
 
         async def fetch_traits(rp):
             try:

--- a/blazar_dashboard/api/client.py
+++ b/blazar_dashboard/api/client.py
@@ -401,6 +401,7 @@ def reservation_calendar(request):
             id=reservation['id'],
             status=reservation.get('status'),
             hypervisor_hostname=hosts_by_id[resource_id].hypervisor_hostname,
+            usage=reservation.get("usage"),
             node_name=compute_host_display_name(hosts_by_id[resource_id]))
         # Only include "extras" for reservations in the current project
         if request.user.project_id == reservation.get('project_id'):
@@ -418,6 +419,13 @@ def reservation_calendar(request):
 
     return compute_hosts, list(chain(*host_reservations))
 
+
+def flavor_reservation_calendar(request):
+    hosts, reservations = reservation_calendar(request)
+    return {
+        "hosts": hosts,
+        "flavors": flavors(request),
+    }, reservations
 
 def network_reservation_calendar(request):
     """Return a list of all scheduled network leases."""

--- a/blazar_dashboard/api/client.py
+++ b/blazar_dashboard/api/client.py
@@ -351,6 +351,10 @@ def compute_host_display_name(host):
     return getattr(host, 'node_name', 'node{}'.format(host.id))
 
 
+def compute_host_display_type(host):
+    return getattr(host, 'node_type', 'unknown')
+
+
 def nodes_in_lease(request, lease):
     """Return list of hypervisor_hostnames in a lease."""
     if not any(
@@ -384,7 +388,7 @@ def reservation_calendar(request):
         host_dict = dict(
             hypervisor_hostname=h.hypervisor_hostname, vcpus=h.vcpus,
             memory_mb=h.memory_mb, local_gb=h.local_gb, cpu_info=h.cpu_info,
-            hypervisor_type=h.hypervisor_type, node_type=h.node_type,
+            hypervisor_type=h.hypervisor_type, node_type=compute_host_display_type(h),
             node_name=compute_host_display_name(h), reservable=h.reservable)
         # Copy these keys if they exist
         for key in ["authorized_projects", "restricted_reason"]:

--- a/blazar_dashboard/api/client.py
+++ b/blazar_dashboard/api/client.py
@@ -10,6 +10,7 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import asyncio
 from datetime import datetime
 from itertools import chain
 import re
@@ -26,6 +27,7 @@ import logging
 from openstack_dashboard.api import base
 from openstack_dashboard.api import neutron
 from openstack_dashboard.api import _nova
+from openstack_dashboard.api import placement
 
 
 LOG = logging.getLogger(__name__)
@@ -422,9 +424,43 @@ def reservation_calendar(request):
 
 def flavor_reservation_calendar(request):
     hosts, reservations = reservation_calendar(request)
+
+    async def fetch_async_data():
+        async def fetch_resource_providers():
+            try:
+                return placement.resource_providers(request)
+            except Exception as e:
+                # If there is an issue with placment API, ignore it
+                return []
+
+        async def fetch_flavors():
+            return flavors(request)
+
+        async def fetch_traits(rp):
+            try:
+                rp["traits"] = placement.resource_provider_traits(
+                    request, rp["uuid"])
+            except Exception as e:
+                # If there is an issue with placment API, ignore it
+                return []
+
+        flavors_task = fetch_flavors()
+        rps = await fetch_resource_providers()
+        host_tasks = [fetch_traits(rp) for rp in rps]
+        *_, flavor_result = await asyncio.gather(*host_tasks, flavors_task)
+        return rps, flavor_result
+
+    # Fetch flavors and host traits. Hosts list is updated in place
+    resource_providers, f = asyncio.run(fetch_async_data())
+    rp_by_name = {
+        rp["name"]: rp for rp in resource_providers
+    }
+    for host in hosts:
+        host["traits"] = rp_by_name.get(
+            host["hypervisor_hostname"], {}).get("traits")
     return {
         "hosts": hosts,
-        "flavors": flavors(request),
+        "flavors": f,
     }, reservations
 
 def network_reservation_calendar(request):

--- a/blazar_dashboard/content/leases/flavor_res_urls.py
+++ b/blazar_dashboard/content/leases/flavor_res_urls.py
@@ -1,0 +1,31 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from blazar_dashboard.content.leases import views as leases_views
+from blazar_dashboard.content.leases.urls import calendar_urlpatterns
+from django.urls import re_path
+
+LEASE_URL = r'^(?P<lease_id>[^/]+)/%s$'
+
+# The virtual leases panel reuses the detail, update and reallocate views; only
+# the index and create views differ, to filter by reservation type and to drop
+# the host step from the workflow.
+urlpatterns = calendar_urlpatterns + [
+    re_path(r'^$', leases_views.VirtualLeasesIndexView.as_view(), name='index'),
+    re_path(r'^create/$', leases_views.VirtualCreateView.as_view(),
+        name='create'),
+    re_path(LEASE_URL % '', leases_views.DetailView.as_view(), name='detail'),
+    re_path(LEASE_URL % 'update', leases_views.UpdateView.as_view(),
+        name='update'),
+    re_path(LEASE_URL % 'reallocate', leases_views.ReallocateView.as_view(),
+        name='reallocate'),
+]

--- a/blazar_dashboard/content/leases/panel.py
+++ b/blazar_dashboard/content/leases/panel.py
@@ -20,3 +20,9 @@ import horizon
 class Leases(horizon.Panel):
     name = _("Leases")
     slug = "leases"
+
+
+class VirtualLeases(Leases):
+    name = _("Virtual Leases")
+    slug = "virtual_leases"
+    urls = 'blazar_dashboard.content.leases.flavor_res_urls'

--- a/blazar_dashboard/content/leases/tables.py
+++ b/blazar_dashboard/content/leases/tables.py
@@ -42,6 +42,10 @@ class CreateLease(tables.LinkAction):
         super(CreateLease, self).__init__(attrs, **kwargs)
 
 
+class CreateVirtualLease(CreateLease):
+    url = "horizon:project:virtual_leases:create"
+
+
 class UpdateLease(tables.LinkAction):
     name = "update"
     verbose_name = _("Update Lease")
@@ -149,6 +153,23 @@ class LeasesTable(tables.DataTable):
             table_actions.insert(0, ViewNetworkReservationCalendar)
         if conf.host_reservation.get('enabled'):
             table_actions.insert(0, ViewHostReservationCalendar)
+        if conf.device_reservation.get('enabled'):
+            table_actions.insert(0, ViewDeviceReservationCalendar)
+
+        row_actions = (UpdateLease, DeleteLease, )
+
+
+class VirtualLeasesTable(LeasesTable):
+    name = tables.Column("name", verbose_name=_("Lease name"),
+                         link="horizon:project:virtual_leases:detail",)
+
+    class Meta(object):
+        name = "virtual_leases"
+        verbose_name = _("Virtual Leases")
+        pagination_param = "marker"
+        table_actions = [CreateVirtualLease, DeleteLease, LeaseFilterAction, ]
+        if conf.network_reservation.get('enabled'):
+            table_actions.insert(0, ViewNetworkReservationCalendar)
         if conf.device_reservation.get('enabled'):
             table_actions.insert(0, ViewDeviceReservationCalendar)
         if conf.flavor_reservation.get('enabled'):

--- a/blazar_dashboard/content/leases/tables.py
+++ b/blazar_dashboard/content/leases/tables.py
@@ -80,6 +80,14 @@ class ViewDeviceReservationCalendar(tables.LinkAction):
     icon = "calendar"
 
 
+class ViewFlavorReservationCalendar(tables.LinkAction):
+    name = "flavor_calendar"
+    verbose_name = _("Flavor Calendar")
+    url = "calendar/flavor/"
+    classes = ("btn-default", )
+    icon = "calendar"
+
+
 class DeleteLease(tables.DeleteAction):
     name = "delete"
     data_type_singular = _("Lease")
@@ -143,5 +151,7 @@ class LeasesTable(tables.DataTable):
             table_actions.insert(0, ViewHostReservationCalendar)
         if conf.device_reservation.get('enabled'):
             table_actions.insert(0, ViewDeviceReservationCalendar)
+        if conf.flavor_reservation.get('enabled'):
+            table_actions.insert(0, ViewFlavorReservationCalendar)
 
         row_actions = (UpdateLease, DeleteLease, )

--- a/blazar_dashboard/content/leases/templates/leases/_scripts.html
+++ b/blazar_dashboard/content/leases/templates/leases/_scripts.html
@@ -4,5 +4,6 @@
 {% block custom_js_files %}
   <script src='{{ STATIC_URL }}leases/js/vendor/apexcharts.min.js' type='text/javascript' charset='utf-8'></script>
   <script src='{{ STATIC_URL }}leases/js/calendar/lease_chart.js' type='text/javascript' charset='utf-8'></script>
+  <script src='{{ STATIC_URL }}leases/js/calendar/lease_flavor_chart.js' type='text/javascript' charset='utf-8'></script>
   <script src='{{ STATIC_URL }}leases/js/create_lease/extra_capability_widget.js' type='text/javascript' charset='utf-8'></script>
 {% endblock %}

--- a/blazar_dashboard/content/leases/templates/leases/calendar_flavor.html
+++ b/blazar_dashboard/content/leases/templates/leases/calendar_flavor.html
@@ -35,6 +35,10 @@
     <select disabled class="form-control" id="resource-type-chooser" name="resource-type-chooser">
     </select>
   </div>
+  <div class="form-group calendar-group">
+    <input id="cookie_offset" type="hidden" value="{{ offset }}" />
+    <span><a href="{{ settings_href }}">Timezone</a>: <b>{{ timezone }}</b></span>
+  </div>
   <h2 id="blazar-calendar-filter-header"></h2>
 </form>
 <div class="blazar-calendar" id="blazar-calendar-flavor">

--- a/blazar_dashboard/content/leases/templates/leases/calendar_flavor.html
+++ b/blazar_dashboard/content/leases/templates/leases/calendar_flavor.html
@@ -1,0 +1,45 @@
+{% extends 'project/leases/base.html' %}
+{% load i18n %}
+{% block title %}{% trans "Leases" %}{% endblock %}
+
+{% block page_header %}
+{% include "horizon/common/_page_header.html" with title=calendar_title %}
+{% endblock page_header %}
+
+{% block main %}
+<form class="form-inline" name="blazar-calendar-controls">
+  <div class="form-group calendar-group">
+    <button class="btn btn-sm btn-default calendar-quickdays" data-calendar-days="1">1 {% trans "day" %}</button>
+    <button class="btn btn-sm btn-default calendar-quickdays" data-calendar-days="7">7 {% trans "days" %}</button>
+    <button class="btn btn-sm btn-default calendar-quickdays" data-calendar-days="30">30 {% trans "days" %}</button>
+  </div>
+  <div class="form-group calendar-group">
+    <label for="dateStart">{% trans "Start" %}</label>
+    <input class="form-control calendar-datebox-date" type="text" name="dateStart" id="dateStart"
+      placeholder="MM/DD/YYYY">
+    <input class="form-control calendar-datebox-hour" type="number" min="00" max="23" name="timeStartHours"
+      id="timeStartHours" placeholder="hh">
+    :
+    00
+  </div>
+  <div class="form-group calendar-group">
+    <label for="dateEnd">{% trans "End" %}</label>
+    <input class="form-control calendar-datebox-date" type="text" name="dateEnd" id="dateEnd" placeholder="MM/DD/YYYY">
+    <input class="form-control calendar-datebox-hour" type="number" min="00" max="23" name="timeEndHours"
+      id="timeEndHours" placeholder="hh">
+    :
+    00
+  </div>
+  <div class="form-group calendar-group">
+    <label for="resource-type-chooser"></label>
+    <select disabled class="form-control" id="resource-type-chooser" name="resource-type-chooser">
+    </select>
+  </div>
+  <h2 id="blazar-calendar-filter-header"></h2>
+</form>
+<div class="blazar-calendar" id="blazar-calendar-flavor">
+  <div class="text-center">
+    <h2>{% trans "Loading Reservations" %}<br><i class="fa fa-spinner fa-spin"></i></h2>
+  </div>
+</div>
+{% endblock %}

--- a/blazar_dashboard/content/leases/templates/leases/create_lease/_flavor_help.html
+++ b/blazar_dashboard/content/leases/templates/leases/create_lease/_flavor_help.html
@@ -2,6 +2,14 @@
 
 {% block help_message %}
 <div class="alert alert-info">
-For reserving an instance of a flavor. Some flavors require reservations to be use.
+<p>
+To launch a virtual machine, you first need to reserve a flavor.
+To launch a bare metal instance, you instead should reserve a host. For the
+full difference, see
+<a href="https://blog.chameleoncloud.org/posts/bare-metal-or-kvm-which-should-you-choose-and-when/">our blog</a>.
+</p>
+<p>
+Some flavors require a reservation in order to be used.
+</p>
 </div>
 {% endblock %}

--- a/blazar_dashboard/content/leases/templates/leases/create_lease/_host_help.html
+++ b/blazar_dashboard/content/leases/templates/leases/create_lease/_host_help.html
@@ -2,8 +2,16 @@
 
 {% block help_message %}
 <div class="alert alert-info">
+<p>
+To launch a bare metal instance, you first need to reserve a host.
+To launch a virtual machine, you instead should reserve a flavor. For the
+full difference, see
+<a href="https://blog.chameleoncloud.org/posts/bare-metal-or-kvm-which-should-you-choose-and-when/">our blog</a>.
+</p>
+<p>
 For specific node reservations, you can find the node UUID using
 <a href="https://www.chameleoncloud.org/user/discovery">Resource Discovery</a>
 on the user portal.
+</p>
 </div>
 {% endblock %}

--- a/blazar_dashboard/content/leases/tests.py
+++ b/blazar_dashboard/content/leases/tests.py
@@ -32,6 +32,8 @@ UPDATE_URL_BASE = 'horizon:project:leases:update'
 UPDATE_TEMPLATE = 'project/leases/update.html'
 FLAVORS_URL = reverse('horizon:project:leases:flavors')
 FLAVOR_CALENDAR_URL = reverse('horizon:project:leases:flavor_calendar')
+VIRTUAL_INDEX_URL = reverse('horizon:project:virtual_leases:index')
+VIRTUAL_CREATE_URL = reverse('horizon:project:virtual_leases:create')
 
 
 class LeasesTests(test.TestCase):
@@ -282,24 +284,31 @@ class LeasesTests(test.TestCase):
         self.assertMessageCount(error=1)
         self.assertRedirectsNoFollow(res, INDEX_URL)
 
+    # conf binds the OPENSTACK_BLAZAR_* settings at import time, so
+    # override_settings does not reach it; patch the module attribute.
+    @mock.patch.object(conf, "flavor_reservation", {"enabled": False})
     def test_flavor_step_not_shown_when_disabled(self):
-        workflow = project_workflows.CreateLease(request=self.request)
+        workflow = project_workflows.VirtualCreateLease(request=self.request)
 
         self.assertNotIn(
             project_workflows.SetFlavors,
             [type(step) for step in workflow.steps],
         )
 
-    # conf binds the OPENSTACK_BLAZAR_* settings at import time, so
-    # override_settings does not reach it; patch the module attribute.
-    @mock.patch.object(conf, "flavor_reservation", {"enabled": True})
     def test_flavor_step_shown_when_enabled(self):
-        workflow = project_workflows.CreateLease(request=self.request)
+        workflow = project_workflows.VirtualCreateLease(request=self.request)
 
         self.assertIn(
             project_workflows.SetFlavors,
             [type(step) for step in workflow.steps],
         )
+
+    def test_flavor_step_not_on_baremetal_workflow(self):
+        workflow = project_workflows.CreateLease(request=self.request)
+
+        step_classes = [type(step) for step in workflow.steps]
+        self.assertNotIn(project_workflows.SetFlavors, step_classes)
+        self.assertIn(project_workflows.SetHosts, step_classes)
 
     @mock.patch.object(api.client, "flavors")
     def test_flavors_json(self, flavors):
@@ -315,13 +324,11 @@ class LeasesTests(test.TestCase):
             res.json(),
         )
 
-    @mock.patch.object(conf, "flavor_reservation", {"enabled": True})
     def test_create_lease_flavor_step_renders(self):
-        res = self.client.get(CREATE_URL)
+        res = self.client.get(VIRTUAL_CREATE_URL)
 
         self.assertContains(res, 'name="flavor_id"')
 
-    @mock.patch.object(conf, "flavor_reservation", {"enabled": True})
     @mock.patch.object(api.client, "lease_list")
     @mock.patch.object(api.client, "lease_create")
     def test_create_lease_flavor_reservation(self, lease_create, lease_list):
@@ -338,7 +345,7 @@ class LeasesTests(test.TestCase):
             "flavor_id": "flavor-uuid",
         }
 
-        res = self.client.post(CREATE_URL, form_data)
+        res = self.client.post(VIRTUAL_CREATE_URL, form_data)
 
         lease_create.assert_called_once_with(
             test.IsHttpRequest(),
@@ -357,9 +364,8 @@ class LeasesTests(test.TestCase):
         )
         self.assertNoFormErrors(res)
         self.assertMessageCount(success=2)
-        self.assertRedirectsNoFollow(res, INDEX_URL)
+        self.assertRedirectsNoFollow(res, VIRTUAL_INDEX_URL)
 
-    @mock.patch.object(conf, "flavor_reservation", {"enabled": True})
     @mock.patch.object(api.client, "lease_list")
     @mock.patch.object(api.client, "lease_create")
     def test_create_lease_flavor_reservation_no_flavor_selected(
@@ -376,12 +382,11 @@ class LeasesTests(test.TestCase):
             "flavor_amount": 2,
         }
 
-        res = self.client.post(CREATE_URL, form_data)
+        res = self.client.post(VIRTUAL_CREATE_URL, form_data)
 
         lease_create.assert_not_called()
         self.assertContains(res, "No flavor is reserved!")
 
-    @mock.patch.object(conf, "flavor_reservation", {"enabled": True})
     @mock.patch.object(api.client, "lease_list")
     @mock.patch.object(api.client, "lease_create")
     def test_create_lease_flavor_reservation_no_amount(
@@ -398,7 +403,7 @@ class LeasesTests(test.TestCase):
             "flavor_id": "flavor-uuid",
         }
 
-        res = self.client.post(CREATE_URL, form_data)
+        res = self.client.post(VIRTUAL_CREATE_URL, form_data)
 
         lease_create.assert_not_called()
         self.assertContains(
@@ -409,3 +414,53 @@ class LeasesTests(test.TestCase):
         res = self.client.get(FLAVOR_CALENDAR_URL)
 
         self.assertContains(res, 'id="cookie_offset"')
+
+    def _lease_reserving(self, name, *resource_types):
+        lease = dict(self.leases.get(name='lease-1').to_dict())
+        lease['id'] = name
+        lease['name'] = name
+        lease['reservations'] = [{'resource_type': rt} for rt in resource_types]
+        return api.client.Lease(lease)
+
+    @mock.patch.object(api.client, 'lease_list')
+    def test_index_excludes_flavor_only_leases(self, lease_list):
+        lease_list.return_value = [
+            self._lease_reserving('host-lease', 'physical:host'),
+            self._lease_reserving('flavor-lease', 'flavor:instance'),
+            self._lease_reserving('both-lease',
+                                  'physical:host', 'flavor:instance'),
+        ]
+
+        res = self.client.get(INDEX_URL)
+
+        self.assertContains(res, 'host-lease')
+        self.assertContains(res, 'both-lease')
+        self.assertNotContains(res, 'flavor-lease')
+
+    @mock.patch.object(api.client, 'lease_list')
+    def test_virtual_index_excludes_host_only_leases(self, lease_list):
+        lease_list.return_value = [
+            self._lease_reserving('host-lease', 'physical:host'),
+            self._lease_reserving('flavor-lease', 'flavor:instance'),
+            self._lease_reserving('both-lease',
+                                  'physical:host', 'flavor:instance'),
+        ]
+
+        res = self.client.get(VIRTUAL_INDEX_URL)
+
+        self.assertContains(res, 'flavor-lease')
+        self.assertContains(res, 'both-lease')
+        self.assertNotContains(res, 'host-lease')
+
+    @mock.patch.object(conf, 'flavor_reservation', {'enabled': False})
+    @mock.patch.object(api.client, 'lease_list')
+    def test_index_unfiltered_when_disabled(self, lease_list):
+        lease_list.return_value = [
+            self._lease_reserving('host-lease', 'physical:host'),
+            self._lease_reserving('flavor-lease', 'flavor:instance'),
+        ]
+
+        res = self.client.get(INDEX_URL)
+
+        self.assertContains(res, 'host-lease')
+        self.assertContains(res, 'flavor-lease')

--- a/blazar_dashboard/content/leases/tests.py
+++ b/blazar_dashboard/content/leases/tests.py
@@ -31,6 +31,7 @@ CREATE_TEMPLATE = 'project/leases/create.html'
 UPDATE_URL_BASE = 'horizon:project:leases:update'
 UPDATE_TEMPLATE = 'project/leases/update.html'
 FLAVORS_URL = reverse('horizon:project:leases:flavors')
+FLAVOR_CALENDAR_URL = reverse('horizon:project:leases:flavor_calendar')
 
 
 class LeasesTests(test.TestCase):
@@ -403,3 +404,8 @@ class LeasesTests(test.TestCase):
         self.assertContains(
             res, "Number of instances is required to reserve a flavor."
         )
+
+    def test_flavor_calendar_supplies_timezone_offset(self):
+        res = self.client.get(FLAVOR_CALENDAR_URL)
+
+        self.assertContains(res, 'id="cookie_offset"')

--- a/blazar_dashboard/content/leases/urls.py
+++ b/blazar_dashboard/content/leases/urls.py
@@ -20,7 +20,8 @@ LEASE_URL = r'^(?P<lease_id>[^/]+)/%s$'
 
 urlpatterns = [
     re_path(r'^calendar/(?P<resource_type>(host|device|network))/$', leases_views.CalendarView.as_view(), name='calendar'),
-    re_path(r'^calendar/(?P<resource_type>(host|device|network))/resources\.json$', leases_views.calendar_data_view,
+    re_path(r'^calendar/flavor/$', leases_views.FlavorCalendarView.as_view(), name='flavor_calendar'),
+    re_path(r'^calendar/(?P<resource_type>(host|device|network|flavor))/resources\.json$', leases_views.calendar_data_view,
         name='calendar_data'),
 
     re_path(r'^(?P<resource_type>[^/]+)/extras\.json$',

--- a/blazar_dashboard/content/leases/urls.py
+++ b/blazar_dashboard/content/leases/urls.py
@@ -18,7 +18,8 @@ from django.urls import re_path
 
 LEASE_URL = r'^(?P<lease_id>[^/]+)/%s$'
 
-urlpatterns = [
+# Shared with the virtual leases panel; see flavor_res_urls.py.
+calendar_urlpatterns = [
     re_path(r'^calendar/(?P<resource_type>(host|device|network))/$', leases_views.CalendarView.as_view(), name='calendar'),
     re_path(r'^calendar/flavor/$', leases_views.FlavorCalendarView.as_view(), name='flavor_calendar'),
     re_path(r'^calendar/(?P<resource_type>(host|device|network|flavor))/resources\.json$', leases_views.calendar_data_view,
@@ -30,6 +31,9 @@ urlpatterns = [
     re_path(r'flavors\.json$',
         leases_views.flavors,
         name='flavors'),
+]
+
+urlpatterns = calendar_urlpatterns + [
     re_path(r'^$', leases_views.IndexView.as_view(), name='index'),
     re_path(r'^create/$', leases_views.CreateView.as_view(), name='create'),
     re_path(LEASE_URL % '', leases_views.DetailView.as_view(),

--- a/blazar_dashboard/content/leases/views.py
+++ b/blazar_dashboard/content/leases/views.py
@@ -70,6 +70,18 @@ class IndexView(tables.PagedTableMixin, tables.DataTableView):
         return leases
 
 
+def add_timezone_context(request, context):
+    """Supply the offset the calendar charts shift their timestamps by."""
+    tz = pytz.timezone(
+        request.session.get('django_timezone',
+                            request.COOKIES.get('django_timezone', 'UTC')))
+    context['timezone'] = tz
+    context['offset'] = int(
+        (datetime.datetime.now(tz).utcoffset().total_seconds() / 60) * -1)
+    context['settings_href'] = reverse('horizon:settings:user:index')
+    return context
+
+
 class CalendarView(views.APIView):
     template_name = 'project/leases/calendar.html'
 
@@ -81,15 +93,7 @@ class CalendarView(views.APIView):
     }
 
     def get_data(self, request, context, *args, **kwargs):
-        tz = pytz.timezone(
-            self.request.session.get('django_timezone',
-                self.request.COOKIES.get('django_timezone', 'UTC'))
-            )
-        context['timezone'] = tz
-        context['offset'] = int(
-            (datetime.datetime.now(tz).utcoffset().total_seconds() / 60) * -1)
-        context['settings_href'] = reverse('horizon:settings:user:index')
-
+        add_timezone_context(self.request, context)
         context["calendar_title"] = self.titles[context["resource_type"]]
         return context
 
@@ -98,6 +102,7 @@ class FlavorCalendarView(views.APIView):
     template_name = "project/leases/calendar_flavor.html"
 
     def get_data(self, request, context, *args, **kwargs):
+        add_timezone_context(self.request, context)
         context["calendar_title"] = _("Flavor Calendar")
         return context
 

--- a/blazar_dashboard/content/leases/views.py
+++ b/blazar_dashboard/content/leases/views.py
@@ -77,6 +77,7 @@ class CalendarView(views.APIView):
         "host": _("Host Calendar"),
         "network": _("Network Calendar"),
         "device": _("Device Calendar"),
+        "flavor": _("Flavor Calendar"),
     }
 
     def get_data(self, request, context, *args, **kwargs):
@@ -93,11 +94,20 @@ class CalendarView(views.APIView):
         return context
 
 
+class FlavorCalendarView(views.APIView):
+    template_name = "project/leases/calendar_flavor.html"
+
+    def get_data(self, request, context, *args, **kwargs):
+        context["calendar_title"] = _("Flavor Calendar")
+        return context
+
+
 def calendar_data_view(request, resource_type):
     api_mapping = {
         "host": api.client.reservation_calendar,
         "network": api.client.network_reservation_calendar,
-        "device": api.client.device_reservation_calendar
+        "device": api.client.device_reservation_calendar,
+        "flavor": api.client.flavor_reservation_calendar,
     }
     data = {}
     resources, reservations = api_mapping[resource_type](request)

--- a/blazar_dashboard/content/leases/views.py
+++ b/blazar_dashboard/content/leases/views.py
@@ -54,6 +54,19 @@ class IndexView(tables.PagedTableMixin, tables.DataTableView):
             **filters,
        }
 
+    def filter_leases(self, leases):
+        """Keep the leases belonging to this panel.
+
+        Baremetal panel: everything except leases that reserve only flavors.
+        Only applies once flavor reservations are enabled and the virtual
+        panel exists to hold them.
+        """
+        if not conf.flavor_reservation.get('enabled', False):
+            return leases
+        return [lease for lease in leases
+                if has_reservation(lease, 'physical:host')
+                or not has_reservation(lease, 'flavor:instance')]
+
     def get_data(self):
         try:
             leases = api.client.lease_list(
@@ -61,13 +74,35 @@ class IndexView(tables.PagedTableMixin, tables.DataTableView):
                 **self.get_data_kwargs(),
             )
             limit = self.get_data_kwargs()['limit']
+            # Derived from the unfiltered page: a full page from Blazar means
+            # more leases exist, whether or not they survive filter_leases().
             self._has_more_data = len(leases) == limit
+            leases = self.filter_leases(leases)
         except Exception:
             leases = []
             self._has_more_data = False
             msg = _('Unable to retrieve lease information.')
             exceptions.handle(self.request, msg)
         return leases
+
+
+class VirtualLeasesIndexView(IndexView):
+    table_class = project_tables.VirtualLeasesTable
+
+    def filter_leases(self, leases):
+        """Keep the leases belonging to the virtual panel.
+
+        The mirror of IndexView.filter_leases: everything except leases that
+        reserve only hosts.
+        """
+        return [lease for lease in leases
+                if has_reservation(lease, 'flavor:instance')
+                or not has_reservation(lease, 'physical:host')]
+
+
+def has_reservation(lease, resource_type):
+    return any(reservation['resource_type'] == resource_type
+               for reservation in lease['reservations'])
 
 
 def add_timezone_context(request, context):
@@ -183,6 +218,10 @@ class CreateView(workflows.WorkflowView):
             initial['max_hosts'] = 1
             initial['computehost_resource_properties'] = f'node_name == {node_name}'
         return initial
+
+
+class VirtualCreateView(CreateView):
+    workflow_class = project_workflows.VirtualCreateLease
 
 
 class UpdateView(workflows.WorkflowView):

--- a/blazar_dashboard/content/leases/workflows.py
+++ b/blazar_dashboard/content/leases/workflows.py
@@ -511,7 +511,11 @@ class SetFlavors(workflows.Step):
     contributes = ("with_flavor", "flavor_amount", "flavor_id")
 
     def allowed(self, request):
-        return conf.flavor_reservation.get("enabled", False)
+        if not conf.flavor_reservation.get("enabled", False):
+            return False
+        # Once enabled, flavor reservations get their own panel and workflow,
+        # so the baremetal workflow stops offering them.
+        return isinstance(self.workflow, VirtualCreateLease)
 
 
 class CreateLease(workflows.Workflow):
@@ -669,6 +673,11 @@ class CreateLease(workflows.Workflow):
             exceptions.handle(request,
                               message='An error occurred while creating this '
                                       'lease: %s. Please try again.' % e)
+
+
+class VirtualCreateLease(CreateLease):
+    default_steps = [SetGeneral, SetFlavors, SetNetworks, SetDevices]
+    success_url = reverse_lazy('horizon:project:virtual_leases:index')
 
 
 class UpdateGeneralAction(workflows.Action):

--- a/blazar_dashboard/enabled/_91_project_reservations_leases_panel.py
+++ b/blazar_dashboard/enabled/_91_project_reservations_leases_panel.py
@@ -28,6 +28,7 @@ ADD_SCSS_FILES = [
 
 ADD_JS_FILES = [
     'leases/js/calendar/lease_chart.js',
+    'leases/js/calendar/lease_flavor_chart.js',
     'leases/js/vendor/apexcharts.min.js',
     'leases/js/create_lease/extra_capability_widget.js',
     'leases/js/create_lease/workflow.js',

--- a/blazar_dashboard/enabled/_92_project_virtual_leases_panel.py
+++ b/blazar_dashboard/enabled/_92_project_virtual_leases_panel.py
@@ -1,0 +1,39 @@
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from blazar_dashboard import conf
+
+# The slug of the panel to be added to HORIZON_CONFIG. Required.
+PANEL = 'virtual_leases'
+# The slug of the panel group the PANEL is associated with.
+PANEL_GROUP = 'reservations'
+# The slug of the dashboard the PANEL associated with. Required.
+PANEL_DASHBOARD = 'project'
+
+# Python panel class of the PANEL to be added. Left unset when flavor
+# reservations are disabled, which leaves the panel unregistered.
+if conf.flavor_reservation.get('enabled', False):
+    ADD_PANEL = 'blazar_dashboard.content.leases.panel.VirtualLeases'
+
+ADD_SCSS_FILES = [
+    'leases/scss/calendar.scss',
+    'leases/scss/detail_overview.scss',
+    'leases/scss/widgets.scss',
+]
+
+ADD_JS_FILES = [
+    'leases/js/calendar/lease_chart.js',
+    'leases/js/calendar/lease_flavor_chart.js',
+    'leases/js/vendor/apexcharts.min.js',
+    'leases/js/create_lease/extra_capability_widget.js',
+    'leases/js/create_lease/workflow.js',
+]

--- a/blazar_dashboard/static/leases/js/calendar/lease_flavor_chart.js
+++ b/blazar_dashboard/static/leases/js/calendar/lease_flavor_chart.js
@@ -1,0 +1,273 @@
+(function (window, horizon, $, undefined) {
+  'use strict';
+
+  var selector = undefined;
+
+  if ($('#blazar-calendar-flavor').length !== 0) {
+    selector = '#blazar-calendar-flavor'
+  }
+
+  if (selector == undefined) return;
+
+  var calendarElement = $(selector);
+  let loaded = false
+  let lastTimeDomain = undefined
+
+  function init() {
+    if (loaded) return;
+
+    $.getJSON("resources.json")
+      .done(function (resp) {
+        // Populator the flavor selection dropdown
+        let selector = $("#resource-type-chooser");
+        selector.empty();
+        resp.resources.flavors.forEach(flavor => {
+          selector.append(new Option(flavor.name, flavor.id));
+        });
+        if (resp.resources.flavors.length > 0) {
+          selector.val(resp.resources.flavors[0].id).change();
+          selector.prop('disabled', false);
+        }
+
+        function maxInstances(flavorId) {
+          // Max number of this flavor across all instances
+          let flavor = resp.resources.flavors.find(f => f.id === flavorId);
+          return resp.resources.hosts.reduce(function (accumulator, host) {
+            let totalVCPUs = host.vcpus;
+            let totalMemory = host.memory_mb;
+            return accumulator + Math.min(
+              Math.floor(totalVCPUs / flavor.vcpus),
+              Math.floor(totalMemory / flavor.ram)
+            )
+          }, 0)
+        }
+
+        function mergeEvents(arr) {
+          // Merge requests if they have the same time. This is required for graphing
+          return arr.reduce((acc, curr) => {
+            if (acc.length > 0 && acc[acc.length - 1].time === curr.time) {
+              let lastObj = acc[acc.length - 1];
+              acc[acc.length - 1] = {
+                time: lastObj.time,
+                changeVCPUs: lastObj.changeVCPUs + curr.changeVCPUs,
+                changeMemory: lastObj.changeMemory + curr.changeMemory,
+                changeInstance: lastObj.changeInstance + curr.changeInstance,
+              };
+            } else {
+              acc.push(curr);
+            }
+            return acc;
+          }, []);
+        }
+
+        function calculateAvailability(flavorId) {
+          // Calculate the availability over time of this flavor
+          // Outline: For each host
+          //   For each reservation on that host
+          //     Calculate delta vcpus/memory at each reservation event {time, dMem, dVcpus}
+          //     Calcualte # of instances at each event {time, # inst}
+          //     Calculate delta of instances at each event {time, dInst}
+          // Combine instance delta over 
+
+          let flavor = resp.resources.flavors.find(f => f.id === flavorId);
+          if (!flavor) return [];
+
+          let instanceChangeEvents = []
+          resp.resources.hosts.forEach(host => {
+            // Calculate delta vcpus/memory at each reservation event
+            let hostEvents = []
+            resp.reservations.filter(r => r.hypervisor_hostname === host.hypervisor_hostname).forEach(reservation => {
+              hostEvents.push(
+                {
+                  time: new Date(reservation.start_date).getTime(),
+                  changeVCPUs: -reservation.usage.vcpus,
+                  changeMemory: -reservation.usage.memory_mb,
+                }
+              );
+              hostEvents.push(
+                {
+                  time: new Date(reservation.end_date).getTime(),
+                  changeVCPUs: reservation.usage.vcpus,
+                  changeMemory: reservation.usage.memory_mb
+                }
+              );
+            });
+            // We merge any allocations with same time together
+            // (e.g. if someone reserves many VMs of the same flavor)
+            hostEvents.sort((a, b) => a.time - b.time);
+            hostEvents = mergeEvents(hostEvents)
+
+            // We calculate available resources at each step. From this, we get # of instances, then delta of instances.
+
+            // Running totals of resources
+            let lastAvailableInstances = Math.min(
+              Math.floor(host.vcpus / flavor.vcpus),
+              Math.floor(host.memory_mb / flavor.ram)
+            )
+            let totalAvailableVCPUs = host.vcpus;
+            let totalAvailableMemory = host.memory_mb;
+            hostEvents.forEach(event => {
+              totalAvailableVCPUs += event.changeVCPUs;
+              totalAvailableMemory += event.changeMemory;
+
+              let totalAvailableInstances = Math.min(
+                Math.trunc(totalAvailableVCPUs / flavor.vcpus),
+                Math.trunc(totalAvailableMemory / flavor.ram)
+              )
+              instanceChangeEvents.push({
+                time: event.time,
+                changeInstance: totalAvailableInstances - lastAvailableInstances
+              })
+              lastAvailableInstances = totalAvailableInstances
+            })
+          });
+          // Merging instance numbers across time and hosts
+          instanceChangeEvents.sort((a, b) => a.time - b.time);
+          instanceChangeEvents = mergeEvents(instanceChangeEvents)
+
+          let maxInstancesNumber = maxInstances(flavorId)
+          // Running total of instances as we iterate over instance changes
+          let availableInstancesNumber = maxInstancesNumber
+          // Data to graph. We start at max instances before first allocation.
+          let timeSeries = [];
+          timeSeries.push({ x: 0, y: maxInstancesNumber })          
+          instanceChangeEvents.forEach(event => {
+            availableInstancesNumber += event.changeInstance;
+            timeSeries.push({
+              x: event.time, y: availableInstancesNumber
+            });
+          })
+          // We end at max instances after all allocations.
+          let lastPoint = timeSeries[timeSeries.length - 1];
+          timeSeries.push({ x: lastPoint.x + 365 * 24 * 60 * 60 * 1000, y: maxInstancesNumber });
+
+          return [{ name: "Total Availability", data: timeSeries }];
+        }
+
+        let chartOptions = {
+          chart: {
+            type: 'line',
+            height: 600,
+            toolbar: { show: false },
+            zoom: { enabled: false, type: 'xy' },
+          },
+          stroke: {
+            curve: 'stepline',
+          },
+          series: [],
+          xaxis: {
+            type: 'datetime'
+          },
+          yaxis: {
+            title: {
+              text: 'Available Instances'
+            },
+            min: 0,
+            labels: {
+              formatter: function (value) {
+                return Math.trunc(value);
+              }
+            }
+          },
+          tooltip: {
+            followCursor: true,
+            x: {
+              format: 'yyyy-MM-dd HH:mm'
+            }
+          },
+        };
+
+        let chart = new ApexCharts(document.querySelector("#blazar-calendar-flavor"), chartOptions);
+        chart.render();
+
+        // Update chart on flavor selection
+        selector.on("change", function () {
+          let selectedFlavor = $(this).val();
+          let availabilityData = calculateAvailability(selectedFlavor);
+
+          let maxInstancesNumber = maxInstances(selectedFlavor)
+          chart.updateOptions({
+            series: availabilityData,
+            yaxis: {
+              min: 0,
+              max: maxInstancesNumber,
+              tickAmount: Math.min(maxInstancesNumber, 20), // Cap number of labels to number of instances.
+            }
+          });
+          if (lastTimeDomain) {
+            setTimeDomain(lastTimeDomain)
+          }
+        });
+        selector.trigger("change");
+
+
+        function computeTimeDomain(days) {
+          var padFraction = 1 / 8;
+          return [
+            d3.time.day.offset(Date.now(), -days * padFraction),
+            d3.time.day.offset(Date.now(), days * (1 + padFraction))
+          ];
+        }
+        function setTimeDomain(timeDomain) {
+          lastTimeDomain = timeDomain
+          form.removeClass('time-domain-processed');
+          $('#dateStart').datepicker('setDate', timeDomain[0]);
+          $('#timeStartHours').val(timeDomain[0].getHours());
+          $('#dateEnd').datepicker('setDate', timeDomain[1]);
+          $('#timeEndHours').val(timeDomain[1].getHours());
+          form.addClass('time-domain-processed');
+          if (chart) {
+            var options = { xaxis: { min: timeDomain[0].getTime(), max: timeDomain[1].getTime() } }
+            chart.updateOptions(options)
+          }
+        }
+
+        function getTimeDomain() {
+          var timeDomain = [
+            $('#dateStart').datepicker('getDate'),
+            $('#dateEnd').datepicker('getDate')
+          ];
+    
+          timeDomain[0].setHours($('#timeStartHours').val());
+          timeDomain[0].setMinutes(0);
+          timeDomain[1].setHours($('#timeEndHours').val());
+          timeDomain[1].setMinutes(0);
+    
+          return timeDomain;
+        }
+    
+        let form = $('form[name="blazar-calendar-controls"]');
+        $('input[data-datepicker]', form).datepicker({
+          dateFormat: 'mm/dd/yyyy'
+        });
+
+        $('input', form).on('change', function () {
+          if (form.hasClass('time-domain-processed')) {
+            var timeDomain = getTimeDomain();
+            // If invalid ordering is chosen, set period to 1 day
+            if (timeDomain[0] >= timeDomain[1]) {
+              timeDomain[1] = d3.time.day.offset(timeDomain[0], +1);
+            }
+            setTimeDomain(timeDomain);
+          }
+        });
+
+        $('.calendar-quickdays').click(function () {
+          var days = parseInt($(this).data("calendar-days"));
+          if (!isNaN(days)) {
+            var timeDomain = computeTimeDomain(days);
+            setTimeDomain(timeDomain);
+          }
+        });
+        setTimeDomain(computeTimeDomain(7));
+
+        loaded = true
+      })
+      .fail(function () {
+        calendarElement.html(`<div class="alert alert-danger">${gettext("Unable to load reservations")}.</div>`);
+      });
+  }
+
+  horizon.addInitFunction(init);
+
+})(window, horizon, jQuery);

--- a/blazar_dashboard/static/leases/js/calendar/lease_flavor_chart.js
+++ b/blazar_dashboard/static/leases/js/calendar/lease_flavor_chart.js
@@ -33,23 +33,6 @@
           // Max number of this flavor across all instances
           let flavor = resp.resources.flavors.find(f => f.id === flavorId);
 
-          function passesTraits(flavor, host){
-            let ret = true;
-            Object.keys(flavor["extra_specs"]).forEach(key => {
-              let value = flavor["extra_specs"][key];
-              if (key.startsWith("trait:")) {
-                let trait = key.split(":")[1];
-                let hostHasTrait = host["traits"].includes(trait);
-                if (value == "forbidden" && hostHasTrait) {
-                  ret = false
-                } else if (value == "required" && !hostHasTrait) {
-                  ret = false
-                }
-              }
-            })
-            return ret;
-          }
-
           return resp.resources.hosts.reduce(function (accumulator, host) {
             let totalVCPUs = host.vcpus;
             let totalMemory = host.memory_mb;
@@ -85,6 +68,23 @@
           }, []);
         }
 
+        function passesTraits(flavor, host){
+          let ret = true;
+          Object.keys(flavor["extra_specs"]).forEach(key => {
+            let value = flavor["extra_specs"][key];
+            if (key.startsWith("trait:")) {
+              let trait = key.split(":")[1];
+              let hostHasTrait = host["traits"].includes(trait);
+              if (value == "forbidden" && hostHasTrait) {
+                ret = false
+              } else if (value == "required" && !hostHasTrait) {
+                ret = false
+              }
+            }
+          })
+          return ret;
+        }
+
         function calculateAvailability(flavorId) {
           // Calculate the availability over time of this flavor
           // Outline: For each host
@@ -99,6 +99,11 @@
 
           let instanceChangeEvents = []
           resp.resources.hosts.forEach(host => {
+            if (!passesTraits(flavor, host)) {
+              // Ignore reservations on incompatible hosts
+              return
+            }
+
             // Calculate delta vcpus/memory at each reservation event
             let hostEvents = []
             resp.reservations.filter(r => r.hypervisor_hostname === host.hypervisor_hostname).forEach(reservation => {

--- a/blazar_dashboard/static/leases/js/calendar/lease_flavor_chart.js
+++ b/blazar_dashboard/static/leases/js/calendar/lease_flavor_chart.js
@@ -18,6 +18,13 @@
 
     $.getJSON("resources.json")
       .done(function (resp) {
+        var localOffsetStr = $('#cookie_offset').val();
+        var tzOffsetDiff = 0; // ms to shift chart
+        if (localOffsetStr) {
+          var userOffset = parseInt(localOffsetStr);
+          tzOffsetDiff = userOffset * -60000;
+        }
+
         // Populator the flavor selection dropdown
         let selector = $("#resource-type-chooser");
         selector.empty();
@@ -131,14 +138,14 @@
               }
               hostEvents.push(
                 {
-                  time: new Date(reservation.start_date).getTime(),
+                  time: new Date(reservation.start_date).getTime() + tzOffsetDiff,
                   changeVCPUs: -vcpus,
                   changeMemory: -memory_mb,
                 }
               );
               hostEvents.push(
                 {
-                  time: new Date(reservation.end_date).getTime(),
+                  time: new Date(reservation.end_date).getTime() + tzOffsetDiff,
                   changeVCPUs: vcpus,
                   changeMemory: memory_mb
                 }
@@ -255,9 +262,10 @@
 
         function computeTimeDomain(days) {
           var padFraction = 1 / 8;
+          var shiftedNow = Date.now() + tzOffsetDiff;
           return [
-            d3.time.day.offset(Date.now(), -days * padFraction),
-            d3.time.day.offset(Date.now(), days * (1 + padFraction))
+            d3.time.day.offset(shiftedNow, -days * padFraction),
+            d3.time.day.offset(shiftedNow, days * (1 + padFraction))
           ];
         }
         function setTimeDomain(timeDomain) {

--- a/blazar_dashboard/static/leases/js/calendar/lease_flavor_chart.js
+++ b/blazar_dashboard/static/leases/js/calendar/lease_flavor_chart.js
@@ -28,7 +28,18 @@
           selector.val(resp.resources.flavors[0].id).change();
           selector.prop('disabled', false);
         }
-        let reservableHosts = resp.resources.hosts.filter(host => host.reservable)
+        let reservableHosts = resp.resources.hosts.filter(host => {
+          if (!host.reservable) {
+            return false;
+          }
+          if (host.authorized_projects) {
+            let projects = host.authorized_projects.split(",");
+            if (!projects.includes(resp.project_id)) {
+              return false;
+            }
+          }
+          return true;
+        });
 
         function maxInstances(flavorId) {
           // Max number of this flavor across all instances
@@ -69,7 +80,7 @@
           }, []);
         }
 
-        function passesTraits(flavor, host){
+        function passesTraits(flavor, host) {
           let ret = true;
           Object.keys(flavor["extra_specs"]).forEach(key => {
             let value = flavor["extra_specs"][key];
@@ -161,7 +172,7 @@
           let availableInstancesNumber = maxInstancesNumber
           // Data to graph. We start at max instances before first allocation.
           let timeSeries = [];
-          timeSeries.push({ x: 0, y: maxInstancesNumber })          
+          timeSeries.push({ x: 0, y: maxInstancesNumber })
           instanceChangeEvents.forEach(event => {
             availableInstancesNumber += event.changeInstance;
             timeSeries.push({
@@ -258,15 +269,15 @@
             $('#dateStart').datepicker('getDate'),
             $('#dateEnd').datepicker('getDate')
           ];
-    
+
           timeDomain[0].setHours($('#timeStartHours').val());
           timeDomain[0].setMinutes(0);
           timeDomain[1].setHours($('#timeEndHours').val());
           timeDomain[1].setMinutes(0);
-    
+
           return timeDomain;
         }
-    
+
         let form = $('form[name="blazar-calendar-controls"]');
         $('input[data-datepicker]', form).datepicker({
           dateFormat: 'mm/dd/yyyy'

--- a/blazar_dashboard/static/leases/js/calendar/lease_flavor_chart.js
+++ b/blazar_dashboard/static/leases/js/calendar/lease_flavor_chart.js
@@ -28,12 +28,13 @@
           selector.val(resp.resources.flavors[0].id).change();
           selector.prop('disabled', false);
         }
+        let reservableHosts = resp.resources.hosts.filter(host => host.reservable)
 
         function maxInstances(flavorId) {
           // Max number of this flavor across all instances
           let flavor = resp.resources.flavors.find(f => f.id === flavorId);
 
-          return resp.resources.hosts.reduce(function (accumulator, host) {
+          return reservableHosts.reduce(function (accumulator, host) {
             let totalVCPUs = host.vcpus;
             let totalMemory = host.memory_mb;
 
@@ -98,7 +99,7 @@
           if (!flavor) return [];
 
           let instanceChangeEvents = []
-          resp.resources.hosts.forEach(host => {
+          reservableHosts.forEach(host => {
             if (!passesTraits(flavor, host)) {
               // Ignore reservations on incompatible hosts
               return

--- a/blazar_dashboard/static/leases/js/calendar/lease_flavor_chart.js
+++ b/blazar_dashboard/static/leases/js/calendar/lease_flavor_chart.js
@@ -119,18 +119,28 @@
             // Calculate delta vcpus/memory at each reservation event
             let hostEvents = []
             resp.reservations.filter(r => r.hypervisor_hostname === host.hypervisor_hostname).forEach(reservation => {
+              var vcpus = 0;
+              var memory_mb = 0;
+              if (!reservation.usage){
+                // If no usage include, then we are using the full host
+                vcpus = host.vcpus;
+                memory_mb = host.memory_mb;
+              } else {
+                vcpus = reservation.usage.vcpus;
+                memory_mb = reservation.usage.memory_mb;
+              }
               hostEvents.push(
                 {
                   time: new Date(reservation.start_date).getTime(),
-                  changeVCPUs: -reservation.usage.vcpus,
-                  changeMemory: -reservation.usage.memory_mb,
+                  changeVCPUs: -vcpus,
+                  changeMemory: -memory_mb,
                 }
               );
               hostEvents.push(
                 {
                   time: new Date(reservation.end_date).getTime(),
-                  changeVCPUs: reservation.usage.vcpus,
-                  changeMemory: reservation.usage.memory_mb
+                  changeVCPUs: vcpus,
+                  changeMemory: memory_mb
                 }
               );
             });

--- a/blazar_dashboard/static/leases/js/calendar/lease_flavor_chart.js
+++ b/blazar_dashboard/static/leases/js/calendar/lease_flavor_chart.js
@@ -32,9 +32,34 @@
         function maxInstances(flavorId) {
           // Max number of this flavor across all instances
           let flavor = resp.resources.flavors.find(f => f.id === flavorId);
+
+          function passesTraits(flavor, host){
+            let ret = true;
+            Object.keys(flavor["extra_specs"]).forEach(key => {
+              let value = flavor["extra_specs"][key];
+              if (key.startsWith("trait:")) {
+                let trait = key.split(":")[1];
+                let hostHasTrait = host["traits"].includes(trait);
+                if (value == "forbidden" && hostHasTrait) {
+                  ret = false
+                } else if (value == "required" && !hostHasTrait) {
+                  ret = false
+                }
+              }
+            })
+            return ret;
+          }
+
           return resp.resources.hosts.reduce(function (accumulator, host) {
             let totalVCPUs = host.vcpus;
             let totalMemory = host.memory_mb;
+
+            if (!passesTraits(flavor, host)) {
+              // Host contributes 0 to capacity if traits don't match
+              totalVCPUs = 0
+              totalMemory = 0;
+            }
+
             return accumulator + Math.min(
               Math.floor(totalVCPUs / flavor.vcpus),
               Math.floor(totalMemory / flavor.ram)

--- a/blazar_dashboard/test/settings.py
+++ b/blazar_dashboard/test/settings.py
@@ -14,10 +14,16 @@
 from horizon.test.settings import *  # noqa: F403,H303
 from openstack_dashboard.test.settings import *  # noqa: F403,H303
 
+# Exercise the split lease UI by default; the tests that need the unsplit
+# behaviour patch conf.flavor_reservation instead. This has to be set before
+# blazar_dashboard.enabled is imported, because conf reads it at import time
+# and _92_project_virtual_leases_panel registers on it.
+OPENSTACK_BLAZAR_FLAVOR_RESERVATION = {'enabled': True}
+
 # Update the dashboards with blazar_dashboard
-import blazar_dashboard.enabled
-import openstack_dashboard.enabled
-from openstack_dashboard.utils import settings
+import blazar_dashboard.enabled  # noqa: E402
+import openstack_dashboard.enabled  # noqa: E402
+from openstack_dashboard.utils import settings  # noqa: E402
 
 # pop these keys to avoid log warnings about deprecation
 # update_dashboards will populate them anyway


### PR DESCRIPTION
Add a new panel to distinguish vm reservations from baremetal ones.

Enabled with conf.flavor_reservation, as settings.CHAMELEON_ENABLE_VMS may not be defined on the horizon side.

Places panel under reservations panelgroup, as baremetal_compute / virtual_compute panel groups may not be defined.

Note: filter_leases runs after paginated fetch, and may render "short" list views.