### PR TITLE
fix: ensure flavor api disabled when conf disabled

### DIFF
--- a/blazar_dashboard/content/leases/tests.py
+++ b/blazar_dashboard/content/leases/tests.py
@@ -32,6 +32,10 @@ UPDATE_URL_BASE = 'horizon:project:leases:update'
 UPDATE_TEMPLATE = 'project/leases/update.html'
 FLAVORS_URL = reverse('horizon:project:leases:flavors')
 FLAVOR_CALENDAR_URL = reverse('horizon:project:leases:flavor_calendar')
+FLAVOR_CALENDAR_DATA_URL = reverse('horizon:project:leases:calendar_data',
+                                   args=['flavor'])
+HOST_CALENDAR_DATA_URL = reverse('horizon:project:leases:calendar_data',
+                                 args=['host'])
 
 
 class LeasesTests(test.TestCase):
@@ -301,6 +305,7 @@ class LeasesTests(test.TestCase):
             [type(step) for step in workflow.steps],
         )
 
+    @mock.patch.object(conf, "flavor_reservation", {"enabled": True})
     @mock.patch.object(api.client, "flavors")
     def test_flavors_json(self, flavors):
         flavors.return_value = [
@@ -405,7 +410,23 @@ class LeasesTests(test.TestCase):
             res, "Number of instances is required to reserve a flavor."
         )
 
+    @mock.patch.object(conf, "flavor_reservation", {"enabled": True})
     def test_flavor_calendar_supplies_timezone_offset(self):
         res = self.client.get(FLAVOR_CALENDAR_URL)
 
         self.assertContains(res, 'id="cookie_offset"')
+
+    def test_flavor_endpoints_absent_when_disabled(self):
+        for url in (FLAVORS_URL, FLAVOR_CALENDAR_URL,
+                    FLAVOR_CALENDAR_DATA_URL):
+            self.assertEqual(404, self.client.get(url).status_code, url)
+
+    @mock.patch.object(api.client, "reservation_calendar")
+    def test_host_calendar_data_unaffected_when_flavor_disabled(
+        self, reservation_calendar
+    ):
+        reservation_calendar.return_value = ([], [])
+
+        res = self.client.get(HOST_CALENDAR_DATA_URL)
+
+        self.assertEqual(200, res.status_code)

--- a/blazar_dashboard/content/leases/views.py
+++ b/blazar_dashboard/content/leases/views.py
@@ -24,6 +24,7 @@ from blazar_dashboard.api import client
 from blazar_dashboard.content.leases import tables as project_tables
 from blazar_dashboard.content.leases import tabs as project_tabs
 from blazar_dashboard.content.leases import workflows as project_workflows
+from django.http import Http404
 from django.http import JsonResponse
 from django.shortcuts import redirect
 from django.urls import reverse
@@ -98,8 +99,17 @@ class CalendarView(views.APIView):
         return context
 
 
+def require_flavor_reservation():
+    if not conf.flavor_reservation.get('enabled', False):
+        raise Http404("flavor reservation is not enabled")
+
+
 class FlavorCalendarView(views.APIView):
     template_name = "project/leases/calendar_flavor.html"
+
+    def dispatch(self, request, *args, **kwargs):
+        require_flavor_reservation()
+        return super().dispatch(request, *args, **kwargs)
 
     def get_data(self, request, context, *args, **kwargs):
         add_timezone_context(self.request, context)
@@ -108,6 +118,8 @@ class FlavorCalendarView(views.APIView):
 
 
 def calendar_data_view(request, resource_type):
+    if resource_type == "flavor":
+        require_flavor_reservation()
     api_mapping = {
         "host": api.client.reservation_calendar,
         "network": api.client.network_reservation_calendar,
@@ -163,6 +175,7 @@ def extra_capabilities(request, resource_type):
 
 
 def flavors(request):
+    require_flavor_reservation()
     return JsonResponse({'flavors': api.client.flavors(request)})
 
 


### PR DESCRIPTION
when flavor_reservation isn't enabled, disable the API endpoint, not just the button for it.